### PR TITLE
exclude HOTP from calculate all and stop hiding search

### DIFF
--- a/Authenticator/Model/YubikitManagerModel.swift
+++ b/Authenticator/Model/YubikitManagerModel.swift
@@ -288,8 +288,14 @@ extension YubikitManagerModel: OperationDelegate {
                     self.calculate(credential: credential)
                 }
                 // if we've got NFC connection and code was not calculated with calculate all
+                // because it requires touch
                 // we can recalculate each individually (touch won't be required over NFC)
-                if !self.keyPluggedIn && credential.requiresRefresh {
+                               
+                // NOTE: we don't update HOTP credentials unless user specifies because
+                // HOTP credentials rely on a counter which is stored on the YubiKey and the validating server.
+                // Each time an OTP is generated the counter is incremented on the YubiKey,
+                // but if the OTP is not sent to the server, the counters get out of sync (there is usually a small window to allow for some drift, around 5 OTPs or so).
+                if !self.keyPluggedIn && credential.requiresRefresh && credential.type == .TOTP{
                     self.calculate(credential: credential)
                 }
             }

--- a/Authenticator/UI/Main/MainViewController.swift
+++ b/Authenticator/UI/Main/MainViewController.swift
@@ -20,6 +20,7 @@ class MainViewController: BaseOATHVIewController {
 
         setupCredentialsSearchController()
         setupNavigationBar()
+        setupRefreshControl()
         
 #if !DEBUG
         if !YubiKitDeviceCapabilities.supportsMFIAccessoryKey && !YubiKitDeviceCapabilities.supportsISO7816NFCTags {
@@ -32,10 +33,6 @@ class MainViewController: BaseOATHVIewController {
 
         // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
         // self.navigationItem.rightBarButtonItem = self.editButtonItem
-        
-        let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action:  #selector(refreshData), for: .valueChanged)
-        self.refreshControl = refreshControl
         
         // observe key plug-in/out changes even in background
         // to make sure we don't leave credentials on screen when key was unplugged
@@ -189,14 +186,11 @@ class MainViewController: BaseOATHVIewController {
         super.onOperationCompleted(operation: operation)
         switch operation {
         case .calculateAll:
-            // show search bar only if there are credentials on the key
-            navigationItem.searchController = viewModel.credentials.count > 0 ? credentialsSearchController : nil
             self.tableView.reloadData()
             break
         case .filter:
             self.tableView.reloadData()
         case .cleanup:
-            navigationItem.searchController = nil
             self.tableView.reloadData()
         default:
             // other operations do not change list of credentials
@@ -288,6 +282,15 @@ class MainViewController: BaseOATHVIewController {
         imageView.image = UIImage(named: "LogoText")
         titleView.addSubview(imageView)
         navigationItem.titleView = titleView
+    }
+    
+    private func setupRefreshControl() {
+        let refreshControl = UIRefreshControl()
+        // setting background to refresh control changes behavior of spinner
+        // and it gets dragged with pull rather than sticks to the top of the view
+        refreshControl.backgroundColor = .clear
+        refreshControl.addTarget(self, action:  #selector(refreshData), for: .valueChanged)
+        self.refreshControl = refreshControl
     }
 
     private func refreshUIOnKeyStateUpdate() {


### PR DESCRIPTION
Search will be present always
RefreshControl will be dragged a bit when pull down to refresh
And HOTP are not calculated until user implicitly taps on that credential