### PR TITLE
Fixes incompatible entitlements

### DIFF
--- a/Authenticator/Authenticator.entitlements
+++ b/Authenticator/Authenticator.entitlements
@@ -4,7 +4,6 @@
 <dict>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
-		<string>NDEF</string>
 		<string>TAG</string>
 	</array>
 	<key>com.apple.security.app-sandbox</key>


### PR DESCRIPTION
Apples toolchain has changed and our entitlements are no longer compatible with App Store. Removing NDEF session format.