### PR TITLE
Change face- and touch-id fallback to YubiKey passcode instead of iOS passcode

### DIFF
--- a/Authenticator/Model/SecureStore/SecureStoreQueryable.swift
+++ b/Authenticator/Model/SecureStore/SecureStoreQueryable.swift
@@ -70,7 +70,7 @@ extension PasswordQueryable: SecureStoreQueryable {
         if useAuthentication {
             query[String(kSecAttrAccessControl)] = SecAccessControlCreateWithFlags(nil, // use the default allocator
                                                                                    kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-                                                                                   .userPresence,
+                                                                                   .biometryCurrentSet,
                                                                                    nil) // ignore any error
             let context = LAContext()
             // Number of seconds to wait between a device unlock with biometric and another biometric authentication request.


### PR DESCRIPTION
This issue was initially pointed out by Chris Halos and found in this thread: https://www.reddit.com/r/cybersecurity/comments/k9b4hd/warning_if_youre_on_ios_and_use_authy_otp_auth_or/. After reviewing the issue it was decided not to act upon it but after further thinking and investigation I decided it needed to be resolved. The main reason behind this is not security but to change the fallback passcode to the YubiKey instead of the phone as this is what most users probably expect.

- When face- or touch-id fails we fallback to the pin of the yubikey instead of the pin of the phone
- Only allow unlock with the set of biometric auth methods (fingers or faces) present when storing the initial YubiKey passcode

Note: This only applies to passcodes stored with this version of the app. Old passcodes still use the old security settings that was used when creating the keychain entry containing the passcode. Finally, this does not necessarily improve security, both iphone and yubikey might have a lower or higher number of characters in their passcode.