### PR TITLE
Fix issue caused by losing tag connection while unlocking YubiKey

### DIFF
--- a/Authenticator/Model/OATHViewModel.swift
+++ b/Authenticator/Model/OATHViewModel.swift
@@ -546,6 +546,7 @@ extension OATHViewModel { //}: OperationDelegate {
             retry?()
         } else {
             // Stop everything and pass error to delegate
+            session = nil
             cleanUp()
             YubiKitManager.shared.stopNFCConnection(withErrorMessage: error.localizedDescription)
             delegate?.onError(error: error)


### PR DESCRIPTION
If the app lost connection to the YubiKey while unlocking the key using face id it would end up in a broken state, still having the session variable in the OATHViewModel, although the session was in a non functional state. This caused any subsequent use of the session to fail.