### PR TITLE
Fix broken gihub build settings

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - name: Test on emulator


### PR DESCRIPTION
In MacOS 11 Github uses a version of Xcode not compatible with the format of the SPM file in our project. This PR locks the version of MacOS at 12 which uses a more modern version of Xcode.