### PR TITLE
Refactored password management

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - name: Test on emulator

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -1080,7 +1080,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Yubico/yubikit-ios";
 			requirement = {
-				branch = "jens/tk-smart-card";
+				branch = "jens/spm-symlinks";
 				kind = branch;
 			};
 		};

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		B40327742847AB5000DF4DB0 /* LicensingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40327732847AB5000DF4DB0 /* LicensingViewController.swift */; };
 		B40327762847AE0A00DF4DB0 /* Licensing.md in Resources */ = {isa = PBXBuildFile; fileRef = B40327752847AE0A00DF4DB0 /* Licensing.md */; };
 		B432B1BF28B65B8600A7182F /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = B432B1BE28B65B8600A7182F /* YubiKit */; };
+		B4712B7028DDB5F6009B270D /* AccessKeyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4712B6F28DDB5F6009B270D /* AccessKeyCache.swift */; };
 		B4B1711827DF8C48002A62DE /* ScanAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B1711727DF8C48002A62DE /* ScanAccountView.swift */; };
 		B9F0FF11F842A39183974083 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 /* End PBXBuildFile section */
@@ -216,6 +217,7 @@
 		A5E9DEAF237DE1660011FBF4 /* SettingsConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsConfig.swift; sourceTree = "<group>"; };
 		B40327732847AB5000DF4DB0 /* LicensingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensingViewController.swift; sourceTree = "<group>"; };
 		B40327752847AE0A00DF4DB0 /* Licensing.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Licensing.md; sourceTree = "<group>"; };
+		B4712B6F28DDB5F6009B270D /* AccessKeyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessKeyCache.swift; sourceTree = "<group>"; };
 		B4B1711727DF8C48002A62DE /* ScanAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanAccountView.swift; sourceTree = "<group>"; };
 		B4E9D46228B65B5100D51FFC /* yubikit-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "yubikit-ios"; path = "../yubikit-ios"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -448,6 +450,7 @@
 				51F8E3BC263847BD0010686B /* ManagementViewModel.swift */,
 				81C00FDA22EB70A500C54903 /* OATHViewModel.swift */,
 				51D1E84D26427F7600BDA3FF /* PasswordCache.swift */,
+				B4712B6F28DDB5F6009B270D /* AccessKeyCache.swift */,
 				515542612649C88900B19C59 /* PasswordConfigurationViewModel.swift */,
 				5155425F2649BDDB00B19C59 /* PasswordStatusViewModel.swift */,
 				5155426926554CAB00B19C59 /* SmartCardViewModel.swift */,
@@ -675,6 +678,7 @@
 				817DBA0D2368B7B7001FC18D /* UIColorAdditions.swift in Sources */,
 				513F34C82464658F00FCE030 /* SettingsRowView.swift in Sources */,
 				51F8E3BF263848E30010686B /* Connection.swift in Sources */,
+				B4712B7028DDB5F6009B270D /* AccessKeyCache.swift in Sources */,
 				513F34DC246B144300FCE030 /* UIViewAdditions.swift in Sources */,
 				A5E9DEB0237DE1660011FBF4 /* SettingsConfig.swift in Sources */,
 				B40327742847AB5000DF4DB0 /* LicensingViewController.swift in Sources */,

--- a/Authenticator/Model/AccessKeyCache.swift
+++ b/Authenticator/Model/AccessKeyCache.swift
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+struct AccessKeyCache {
+    
+    let timeToLive = TimeInterval(5*60)
+    
+    struct AccessKey {
+        let timeStamp = Date()
+        let accessKey: Data
+        
+        init(_ accessKey: Data) {
+            self.accessKey = accessKey
+        }
+    }
+    
+    private var cache = [String: AccessKey]()
+    
+    mutating func accessKey(forKey index: String) -> Data? {
+        guard let possibleAccessKey = cache[index] else { return nil }
+        if Date() < Date(timeInterval: timeToLive, since: possibleAccessKey.timeStamp) {
+            cache[index] = AccessKey(possibleAccessKey.accessKey)
+            return possibleAccessKey.accessKey
+        } else {
+            cache.removeValue(forKey: index)
+            return nil
+        }
+    }
+    
+    mutating func setAccessKey(_ accessKey: Data, forKey index: String) {
+        let accessKey = AccessKey(accessKey)
+        cache[index] = accessKey
+    }
+}

--- a/Authenticator/Model/FavoritesStorage.swift
+++ b/Authenticator/Model/FavoritesStorage.swift
@@ -19,17 +19,23 @@ import Foundation
 // This class is for storing a set of favorite credentials in UserDefaults by keyIdentifier.
 class FavoritesStorage: NSObject {
     
-    func saveFavorites(userAccount: String?, favorites: Set<String>) {
-        guard let keyId = userAccount,
+    func migrate(fromKeyIdentifier: String, toKeyIdentifier: String) {
+        guard let encodedData = UserDefaults.standard.data(forKey: "Favorites-" + fromKeyIdentifier) else { return }
+        UserDefaults.standard.setValue(encodedData, forKey: "Favorites-" + toKeyIdentifier)
+        UserDefaults.standard.removeObject(forKey: "Favorites-" + fromKeyIdentifier)
+    }
+    
+    func saveFavorites(keyIdentifier: String?, favorites: Set<String>) {
+        guard let keyIdentifier,
               let encodedData = try? NSKeyedArchiver.archivedData(withRootObject: favorites, requiringSecureCoding: true) else {
             return
         }
-        UserDefaults.standard.setValue(encodedData, forKey: "Favorites-" + keyId)
+        UserDefaults.standard.setValue(encodedData, forKey: "Favorites-" + keyIdentifier)
     }
     
-    func readFavorites(userAccount: String?) -> Set<String> {
-        guard let keyId = userAccount,
-              let encodedData = UserDefaults.standard.data(forKey: "Favorites-" + keyId),
+    func readFavorites(keyIdentifier: String?) -> Set<String> {
+        guard let keyIdentifier,
+              let encodedData = UserDefaults.standard.data(forKey: "Favorites-" + keyIdentifier),
               let favorites = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(encodedData) as? Set<String> else {
             return Set<String>()
         }

--- a/Authenticator/Model/FavoritesStorage.swift
+++ b/Authenticator/Model/FavoritesStorage.swift
@@ -25,17 +25,15 @@ class FavoritesStorage: NSObject {
         UserDefaults.standard.removeObject(forKey: "Favorites-" + fromKeyIdentifier)
     }
     
-    func saveFavorites(keyIdentifier: String?, favorites: Set<String>) {
-        guard let keyIdentifier,
-              let encodedData = try? NSKeyedArchiver.archivedData(withRootObject: favorites, requiringSecureCoding: true) else {
+    func saveFavorites(keyIdentifier: String, favorites: Set<String>) {
+        guard let encodedData = try? NSKeyedArchiver.archivedData(withRootObject: favorites, requiringSecureCoding: true) else {
             return
         }
         UserDefaults.standard.setValue(encodedData, forKey: "Favorites-" + keyIdentifier)
     }
     
-    func readFavorites(keyIdentifier: String?) -> Set<String> {
-        guard let keyIdentifier,
-              let encodedData = UserDefaults.standard.data(forKey: "Favorites-" + keyIdentifier),
+    func readFavorites(keyIdentifier: String) -> Set<String> {
+        guard let encodedData = UserDefaults.standard.data(forKey: "Favorites-" + keyIdentifier),
               let favorites = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(encodedData) as? Set<String> else {
             return Set<String>()
         }

--- a/Authenticator/Model/OATHViewModel.swift
+++ b/Authenticator/Model/OATHViewModel.swift
@@ -22,7 +22,7 @@ protocol CredentialViewModelDelegate: AnyObject {
     func onOperationCompleted(operation: OperationName)
     func onShowToastMessage(message: String)
     func onCredentialDelete(credential: Credential)
-    func collectUserPassword(isPasswordEntryRetry: Bool, completion: @escaping (String?) -> Void)
+    func collectPassword(isPasswordEntryRetry: Bool, completion: @escaping (String?) -> Void)
     func collectPasswordPreferences(completion: @escaping (PasswordSaveType) -> Void)
 }
 
@@ -637,7 +637,7 @@ extension OATHViewModel { //}: OperationDelegate {
                     self.unlock(withAccessKey: accessKey, completion: retry)
                 } else {
                     YubiKitManager.shared.stopNFCConnection(withErrorMessage: error.localizedDescription)
-                    self.delegate?.collectUserPassword(isPasswordEntryRetry: false) { password in
+                    self.delegate?.collectPassword(isPasswordEntryRetry: false) { password in
                         guard let password else { fatalError("No password") }
                         self.unlock(withPassword: password, completion: retry)
                     }
@@ -645,7 +645,7 @@ extension OATHViewModel { //}: OperationDelegate {
             }
         // Ask user for the correct password
         } else if errorCode == .wrongPassword {
-            self.delegate?.collectUserPassword(isPasswordEntryRetry: true) { password in
+            self.delegate?.collectPassword(isPasswordEntryRetry: true) { password in
                 guard let password else { fatalError("No password") }
                 self.unlock(withPassword: password, completion: retry)
             }

--- a/Authenticator/Model/OATHViewModel.swift
+++ b/Authenticator/Model/OATHViewModel.swift
@@ -402,9 +402,8 @@ class OATHViewModel: NSObject, YKFManagerDelegate {
                 }
                 if self.isPinned(credential: credential) {
                     self.unPin(credential: credential)
-                } else {
-                    self.calculateAll()
                 }
+                self.calculateAll()
                 self.onDelete(credential: credential)
             }
         }
@@ -821,7 +820,6 @@ extension OATHViewModel {
             return
         }
         self.favoritesStorage.saveFavorites(keyIdentifier: keyIdentifier, favorites: self.favorites)
-        calculateAll()
     }
     
     func unPin(credential: Credential) {
@@ -831,7 +829,6 @@ extension OATHViewModel {
         }
         self.favorites.remove(credential.uniqueId)
         self.favoritesStorage.saveFavorites(keyIdentifier: keyIdentifier, favorites: self.favorites)
-        calculateAll()
     }
 }
 

--- a/Authenticator/Model/OATHViewModel.swift
+++ b/Authenticator/Model/OATHViewModel.swift
@@ -750,10 +750,8 @@ extension OATHViewModel {
         if let accessoryConnection {
             return accessoryConnection.accessoryDescription?.serialNumber
         }
-        if let smartCardConnection {
-            // TODO: add an identifier for SmartCardConnection
-            print("No identifier for SmartCardConnection!")
-            return nil
+        if smartCardConnection != nil {
+            return self.session?.deviceId
         }
         if let nfcConnection {
             return nfcConnection.tagDescription?.identifier.hex

--- a/Authenticator/Model/SecureStore/PasswordPreferences.swift
+++ b/Authenticator/Model/SecureStore/PasswordPreferences.swift
@@ -52,7 +52,7 @@ class PasswordPreferences {
     /* This method returns what biometric authentiacation type set on user's device.
     canEvaluatePolicy should be called before getting the biometryType.
     */
-    func evaluatedAuthenticationType() -> AuthenticationType {
+    static func evaluatedAuthenticationType() -> AuthenticationType {
         let context = LAContext()
         var errorPolicy: NSError?
         var errorBiometricPolicy: NSError?
@@ -83,6 +83,14 @@ class PasswordPreferences {
         return .touchId
     }
     
+    func migrate(fromKeyIdentifier: String, toKeyIdentifier: String) {
+        if UserDefaults.standard.value(forKey: UIViewController.PasswordUserDefaultsKey + fromKeyIdentifier) != nil {
+            let value = UserDefaults.standard.integer(forKey: UIViewController.PasswordUserDefaultsKey + fromKeyIdentifier)
+            UserDefaults.standard.set(value, forKey: UIViewController.PasswordUserDefaultsKey + toKeyIdentifier)
+            UserDefaults.standard.removeObject(forKey: UIViewController.PasswordUserDefaultsKey + fromKeyIdentifier)
+        }
+    }
+    
     func neverSavePassword(keyIdentifier: String) -> Bool {
         return UserDefaults.standard.integer(forKey: UIViewController.PasswordUserDefaultsKey + keyIdentifier) == PasswordSaveType.never.rawValue
     }
@@ -108,7 +116,7 @@ class PasswordPreferences {
     func resetPasswordPreferenceForAll() {
         for key in UserDefaults.standard.dictionaryRepresentation().keys {
             if key.starts(with: UIViewController.PasswordUserDefaultsKey) {
-                UserDefaults.standard.set(PasswordSaveType.none.rawValue, forKey: key)
+                UserDefaults.standard.removeObject(forKey: key)
             }
         }
     }

--- a/Authenticator/Model/SecureStore/SecureStoreError.swift
+++ b/Authenticator/Model/SecureStore/SecureStoreError.swift
@@ -33,6 +33,7 @@ import Foundation
 public enum SecureStoreError: Error {
     case string2DataConversionError
     case data2StringConversionError
+    case dataCastError
     case unhandledError(message: String)
     case itemNotFound
 }
@@ -46,6 +47,8 @@ extension SecureStoreError: LocalizedError {
             return NSLocalizedString("String to Data conversion error", comment: "")
         case .data2StringConversionError:
             return NSLocalizedString("Data to String conversion error", comment: "")
+        case .dataCastError:
+            return NSLocalizedString("Failed to cast object to Data error", comment: "")
         case .unhandledError(let message):
             return NSLocalizedString(message, comment: "")
         case .itemNotFound:

--- a/Authenticator/UI/Authentication/OATHCodeDetailsView.swift
+++ b/Authenticator/UI/Authentication/OATHCodeDetailsView.swift
@@ -148,6 +148,7 @@ class OATHCodeDetailsView: UIVisualEffectView {
                                   image: UIImage(systemName: "pin.slash"),
                                   action: { [weak self] in
                     viewModel.unPin(credential: credential)
+                    viewModel.calculateAll()
                     self?.dismiss()
                 })
             } else {
@@ -155,6 +156,7 @@ class OATHCodeDetailsView: UIVisualEffectView {
                                   image: UIImage(systemName: "pin"),
                                   action: { [weak self] in
                     viewModel.pin(credential: credential)
+                    viewModel.calculateAll()
                     self?.dismiss()
                 })
             }

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -572,7 +572,7 @@ extension OATHViewController: CredentialViewModelDelegate {
         }
     }
 
-    func collectUserPassword(isPasswordEntryRetry: Bool, completion: @escaping (String?) -> Void) {
+    func collectPassword(isPasswordEntryRetry: Bool, completion: @escaping (String?) -> Void) {
         DispatchQueue.main.async {
             let passwordEntryAlert = UIAlertController(passwordEntryType: isPasswordEntryRetry ? .retryPassword : .password) { password in
                 completion(password)

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -516,7 +516,7 @@ extension OATHViewController: CredentialViewModelDelegate {
     
     // MARK: - CredentialViewModelDelegate
     
-    func showAlert(title: String, message: String) {
+    func showAlert(title: String, message: String?) {
         self.showAlertDialog(title: title, message: message, okHandler:  { [weak self] () -> Void in
             self?.dismiss(animated: true, completion: nil)
         })

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -20,10 +20,6 @@ import Combine
 class OATHViewController: UITableViewController {
 
     let viewModel = OATHViewModel()
-    let passwordPreferences = PasswordPreferences()
-    var passwordCache = PasswordCache()
-    let secureStore = SecureStore(secureStoreQueryable: PasswordQueryable(service: "OATH"))
-    
     var detailView: OATHCodeDetailsView?
     
     @IBOutlet weak var menuButton: UIBarButtonItem!
@@ -520,17 +516,16 @@ extension OATHViewController: CredentialViewModelDelegate {
     
     // MARK: - CredentialViewModelDelegate
     
-    /*! Delegate method that invoked when any operation failed
-     * Operation could be from YubiKit operations (e.g. calculate) or QR scanning (e.g. scan code)
-     */
+    func showAlert(title: String, message: String) {
+        self.showAlertDialog(title: title, message: message, okHandler:  { [weak self] () -> Void in
+            self?.dismiss(animated: true, completion: nil)
+        })
+    }
+
     func onError(error: Error) {
-        // not sure we will need this
-        print("Got error: \(error)")
+        showAlert(title: "Something went wrong", message: error.localizedDescription)
     }
     
-    /*! Delegate method that invoked when any operation succeeded
-     * Operation could be from YubiKit (e.g. calculate) or local (e.g. filter)
-     */
     func onOperationCompleted(operation: OperationName) {
         switch operation {
         case .setCode:
@@ -568,66 +563,21 @@ extension OATHViewController: CredentialViewModelDelegate {
         self.tableView.reloadData()
     }
     
-    func didValidatePassword(_ password: String, forKey key: String) {
-        // Cache password in memory
-        passwordCache.setPassword(password, forKey: key)
-        
-        // Check if we should save password in keychain
-        if !self.passwordPreferences.neverSavePassword(keyIdentifier: key) {
-            self.secureStore.getValue(for: key) { result in
-                let currentPassword = try? result.get()
-                if password != currentPassword {
-                    let passwordActionSheet = UIAlertController(passwordPreferences: self.passwordPreferences) { type in
-                        self.passwordPreferences.setPasswordPreference(saveType: type, keyIdentifier: key)
-                        if self.passwordPreferences.useSavedPassword(keyIdentifier: key) || self.passwordPreferences.useScreenLock(keyIdentifier: key) {
-                            do {
-                                try self.secureStore.setValue(password, useAuthentication: self.passwordPreferences.useScreenLock(keyIdentifier: key), for: key)
-                            } catch let e {
-                                self.passwordPreferences.resetPasswordPreference(keyIdentifier: key)
-                                self.showAlertDialog(title: "Password was not saved", message: e.localizedDescription)
-                            }
-                        }
-                    }
-                    DispatchQueue.main.async {
-                        self.present(passwordActionSheet, animated: true, completion: nil)
-                    }
-                }
-            }
+    func collectPasswordPreferences(completion: @escaping (PasswordSaveType) -> Void) {
+        let passwordActionSheet = UIAlertController { type in
+            completion(type)
+        }
+        DispatchQueue.main.async {
+            self.present(passwordActionSheet, animated: true)
         }
     }
-    
-    func cachedPasswordFor(keyId: String, completion: @escaping (String?) -> Void) {
-        if let password = passwordCache.password(forKey: keyId) {
-            completion(password)
-            return
-        }
-        self.secureStore.getValue(for: keyId) { result in
-            let password = try? result.get()
-            completion(password)
-            return
-        }
-    }
-    
-    func passwordFor(keyId: String, isPasswordEntryRetry: Bool, completion: @escaping (String?) -> Void) {
+
+    func collectUserPassword(isPasswordEntryRetry: Bool, completion: @escaping (String?) -> Void) {
         DispatchQueue.main.async {
             let passwordEntryAlert = UIAlertController(passwordEntryType: isPasswordEntryRetry ? .retryPassword : .password) { password in
                 completion(password)
             }
             self.present(passwordEntryAlert, animated: true)
-        }
-    }
-    
-    private func removeStoredPasswords() {
-        passwordPreferences.resetPasswordPreferenceForAll()
-        do {
-            try secureStore.removeAllValues()
-            self.showAlertDialog(title: "Success", message: "Stored passwords have been cleared from this phone.", okHandler:  { [weak self] () -> Void in
-                self?.dismiss(animated: true, completion: nil)
-            })
-        } catch let e {
-            self.showAlertDialog(title: "Failed to clear stored passwords.", message: e.localizedDescription, okHandler:  { [weak self] () -> Void in
-                self?.dismiss(animated: true, completion: nil)
-            })
         }
     }
     

--- a/Authenticator/UI/Helpers/UIAlertController+Extensions.swift
+++ b/Authenticator/UI/Helpers/UIAlertController+Extensions.swift
@@ -60,8 +60,8 @@ extension UIAlertController {
         self.addAction(cancel)
     }
     
-    convenience init(passwordPreferences preferences: PasswordPreferences, completion: @escaping (PasswordSaveType) -> Void) {
-        let authenticationType = preferences.evaluatedAuthenticationType()
+    convenience init(completion: @escaping (PasswordSaveType) -> Void) {
+        let authenticationType = PasswordPreferences.evaluatedAuthenticationType()
         
         self.init(title: "Would you like to save this password for YubiKey for next usage in this application?",
                   message: "You can remove saved password in Settings.",

--- a/Authenticator/UI/YubiKeyConfiguration/OATHConfigurationController.swift
+++ b/Authenticator/UI/YubiKeyConfiguration/OATHConfigurationController.swift
@@ -150,8 +150,8 @@ class OATHConfigurationController: UITableViewController {
             self.showAlertDialog(title: "Success", message: "Stored passwords have been cleared from this phone.", okHandler:  { [weak self] () -> Void in
                 self?.dismiss(animated: true, completion: nil)
             })
-        } catch let e {
-            self.showAlertDialog(title: "Failed to clear passwords.", message: e.localizedDescription, okHandler:  { [weak self] () -> Void in
+        } catch {
+            self.showAlertDialog(title: "Failed to clear passwords", message: error.localizedDescription, okHandler:  { [weak self] () -> Void in
                 self?.dismiss(animated: true, completion: nil)
             })
         }


### PR DESCRIPTION
- Added support for saving passwords on iPads with USB-C port.
- Moved password management from view controller to the model
- Migrate passwords stored with the old key identifiers and store access key for the key instead using the deviceId of the session
- Migrate pinned accounts