### PR TITLE
iPad improvements

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -779,7 +779,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = TokenExtension/TokenExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 82;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				INFOPLIST_FILE = TokenExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
@@ -802,7 +802,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = TokenExtension/TokenExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 82;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				INFOPLIST_FILE = TokenExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
@@ -945,7 +945,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Authenticator/Authenticator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 82;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				HEADER_SEARCH_PATHS = "../Submodules/YubiKit/**";
 				INFOPLIST_FILE = Authenticator/Info.plist;
@@ -973,7 +973,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Authenticator/Authenticator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 82;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				HEADER_SEARCH_PATHS = "../Submodules/YubiKit/**";
 				INFOPLIST_FILE = Authenticator/Info.plist;

--- a/Authenticator/AppDelegate.swift
+++ b/Authenticator/AppDelegate.swift
@@ -26,9 +26,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if YubiKitDeviceCapabilities.supportsMFIAccessoryKey {
             YubiKitManager.shared.startAccessoryConnection()
         }
-        if #available(iOS 16, *) {
-            YubiKitManager.shared.startSmartCardConnection()
-        }
         if let main = UIApplication.shared.windows.first?.rootViewController?.children.first as? OATHViewController {
             UNUserNotificationCenter.current().delegate = main
         }
@@ -41,6 +38,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
+        if #available(iOS 16.0, *) {
+            YubiKitManager.shared.stopSmartCardConnection()
+        }
+
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
@@ -50,7 +51,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+        if #available(iOS 16, *) {
+            YubiKitManager.shared.startSmartCardConnection()
+        }
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/Authenticator/Model/OATHViewModel.swift
+++ b/Authenticator/Model/OATHViewModel.swift
@@ -621,9 +621,8 @@ extension OATHViewModel { //}: OperationDelegate {
     
     /*! Invoked when operation/request to YubiKey failed */
     func onError(error: Error, retry: (() -> Void)? = nil) {
-        let errorCode = YKFOATHErrorCode(rawValue: UInt((error as NSError).code))
         // Try cached passwords and then ask user for password
-        if errorCode == .authenticationRequired {
+        if let oathError = error as? YKFOATHError, oathError.code == YKFOATHErrorCode.authenticationRequired.rawValue {
             self.cachedAccessKey { accessKey in
                 if let accessKey {
                     self.unlock(withAccessKey: accessKey, completion: retry)
@@ -636,7 +635,7 @@ extension OATHViewModel { //}: OperationDelegate {
                 }
             }
         // Ask user for the correct password
-        } else if errorCode == .wrongPassword {
+        } else if let oathError = error as? YKFOATHError, oathError.code == YKFOATHErrorCode.wrongPassword.rawValue {
             self.delegate?.collectPassword(isPasswordEntryRetry: true) { password in
                 guard let password else { fatalError("No password") }
                 self.unlock(withPassword: password, completion: retry)

--- a/Authenticator/Model/PasswordConfigurationViewModel.swift
+++ b/Authenticator/Model/PasswordConfigurationViewModel.swift
@@ -43,8 +43,7 @@ class PasswordConfigurationViewModel {
                     // This unlock is a local extension that accepts an optional String as password
                     session.unlock(password: oldPassword) { error in
                         if let error = error {
-                            let errorCode = YKFOATHErrorCode(rawValue: UInt((error as NSError).code))
-                            if errorCode == .wrongPassword {
+                            if let oathError = error as? YKFOATHError, oathError.code == YKFOATHErrorCode.wrongPassword.rawValue {
                                 YubiKitManager.shared.stopNFCConnection(withErrorMessage: "Wrong password")
                                 completion(.wrongPassword)
                                 return
@@ -55,8 +54,7 @@ class PasswordConfigurationViewModel {
                         }
                         session.setPassword(password) { error in
                             if let error = error {
-                                let errorCode = YKFOATHErrorCode(rawValue: UInt((error as NSError).code))
-                                if errorCode == .authenticationRequired {
+                                if let oathError = error as? YKFOATHError, oathError.code == YKFOATHErrorCode.authenticationRequired.rawValue {
                                     YubiKitManager.shared.stopNFCConnection(withErrorMessage: "Authentication required")
                                     completion(.authenticationRequired)
                                     return

--- a/Authenticator/Model/PasswordStatusViewModel.swift
+++ b/Authenticator/Model/PasswordStatusViewModel.swift
@@ -68,8 +68,7 @@ class PasswordStatusViewModel: NSObject, YKFManagerDelegate {
                     guard let session = session else { self?.passwordStatusCallback?(.unknown); return }
                     session.listCredentials { _, error in
                         guard let error = error else { self?.passwordStatusCallback?(.noPassword); return }
-                        let errorCode = YKFOATHErrorCode(rawValue: UInt((error as NSError).code))
-                        if errorCode == .authenticationRequired {
+                        if let oathError = error as? YKFOATHError, oathError.code == YKFOATHErrorCode.authenticationRequired.rawValue {
                             self?.passwordStatusCallback?(.isProtected)
                         } else {
                             self?.passwordStatusCallback?(.unknown)

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -16,6 +16,7 @@
 
 import UIKit
 import Combine
+import CryptoTokenKit
 
 class OATHViewController: UITableViewController {
 
@@ -294,8 +295,10 @@ class OATHViewController: UITableViewController {
         }
         let credential = credentialAt(indexPath)
         
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(.success)
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            let generator = UINotificationFeedbackGenerator()
+            generator.notificationOccurred(.success)
+        }
 
         if credential.requiresRefresh {
             viewModel.calculate(credential: credential) { [self] _ in
@@ -523,6 +526,11 @@ extension OATHViewController: CredentialViewModelDelegate {
     }
 
     func onError(error: Error) {
+        let nsError = error as NSError
+        if nsError.domain == TKErrorDomain && nsError.code == -2 {
+            showAlert(title: "Require Touch currently unsupported on iPad", message: "Due to a limitation in the current USB smart card implementation for iPad, require touch unfortunately does not yet work on this device.")
+            return
+        }
         showAlert(title: "Something went wrong", message: error.localizedDescription)
     }
     

--- a/Authenticator/VersionHistory.plist
+++ b/Authenticator/VersionHistory.plist
@@ -6,14 +6,14 @@
         <key>version</key>
         <string>1.7.0</string>
         <key>date</key>
-        <date>2022-10-17T09:41:00Z</date>
+        <date>2022-10-24T09:41:00Z</date>
         <key>shouldPromptUser</key>
-        <false/>
+        <true/>
         <key>changes</key>
-        <string>The major news for this version is added USB-C support on iPads running iPadOS 16! We've also made the following changes to the app:
-            - Fixes bug where requires touch setting was ignored when creating a new account.
-            - Fixes bug in Steam account creation when bypass touch was enabled for NFC keys.
-            - When deleting an account the correct one would be deleted on the YubiKey, but the list of accounts in the app would be out of sync.
+        <string>The major update for this version is added USB-C support on iPads running iPadOS 16. We've also made the following changes to the app:
+            - Fixed the bug where the required touch setting was ignored when creating a new account.
+            - Fixed the bug in Steam account creation when bypass touch was enabled for NFC keys.
+            - Fixed the bug where deleting an account would cause a sync issue between the YubiKey and Yubico Authenticator.
             - Storage of passwords in the keychain has been improved and now uses the derived access key. Old stored passwords will be migrated automatically.
             - The previous settings for account creation are no longer re-used for the next account.
             - Menu items for account and configuration are now disabled on iPads when no YubiKey is inserted into the device.


### PR DESCRIPTION
- Handle launching with key already inserted better.
- Show error message when the smart card connection times out while waiting for touch
- Only run haptic feedback on iPhone
- Updated version history