### PR TITLE
Adds support for reading Yubico OTP

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Test on emulator
-        run: xcodebuild clean test -disablePackageRepositoryCache -sdk iphonesimulator -project Authenticator.xcodeproj -scheme Authenticator -destination "platform=iOS Simulator,OS=latest,name=iPhone 13" | xcpretty --test --color && exit ${PIPESTATUS[0]}
+        run: xcodebuild clean test -disablePackageRepositoryCache -sdk iphonesimulator -project Authenticator.xcodeproj -scheme Authenticator -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" | xcpretty --test --color && exit ${PIPESTATUS[0]}

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		B432B1BF28B65B8600A7182F /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = B432B1BE28B65B8600A7182F /* YubiKit */; };
 		B4712B7028DDB5F6009B270D /* AccessKeyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4712B6F28DDB5F6009B270D /* AccessKeyCache.swift */; };
 		B4B1711827DF8C48002A62DE /* ScanAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B1711727DF8C48002A62DE /* ScanAccountView.swift */; };
+		B4EE055F2A0CDB3C002F30D4 /* OTPTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EE055E2A0CDB3C002F30D4 /* OTPTableViewCell.swift */; };
 		B9F0FF11F842A39183974083 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 /* End PBXBuildFile section */
 
@@ -220,6 +221,7 @@
 		B4712B6F28DDB5F6009B270D /* AccessKeyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessKeyCache.swift; sourceTree = "<group>"; };
 		B4B1711727DF8C48002A62DE /* ScanAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanAccountView.swift; sourceTree = "<group>"; };
 		B4E9D46228B65B5100D51FFC /* yubikit-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "yubikit-ios"; path = "../yubikit-ios"; sourceTree = "<group>"; };
+		B4EE055E2A0CDB3C002F30D4 /* OTPTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -258,6 +260,7 @@
 				818866F722E8E19D006BC0A8 /* CredentialTableViewCell.swift */,
 				51E9BE3926D9038C00F9E2FC /* OATHCodeDetailsView.swift */,
 				818866F922E96B47006BC0A8 /* PieProgressBar.swift */,
+				B4EE055E2A0CDB3C002F30D4 /* OTPTableViewCell.swift */,
 				513F34BC24633A4A00FCE030 /* EditCredential */,
 				81FA3C2B2319839B009C22AB /* AddCredential */,
 			);
@@ -684,6 +687,7 @@
 				B40327742847AB5000DF4DB0 /* LicensingViewController.swift in Sources */,
 				51AFD4D227103E36008F2630 /* SearchBar.swift in Sources */,
 				811CD95722FB276A00E2BCBB /* HelpViewController.swift in Sources */,
+				B4EE055F2A0CDB3C002F30D4 /* OTPTableViewCell.swift in Sources */,
 				81C00FDB22EB70A500C54903 /* OATHViewModel.swift in Sources */,
 				818866E922E18134006BC0A8 /* OATHViewController.swift in Sources */,
 				51D1E84C264134F300BDA3FF /* UIAlertController+Extensions.swift in Sources */,
@@ -779,7 +783,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = TokenExtension/TokenExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 107;
+				CURRENT_PROJECT_VERSION = 110;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				INFOPLIST_FILE = TokenExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
@@ -788,7 +792,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.3;
+				MARKETING_VERSION = 1.7.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yubico.Authenticator.TokenExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -802,7 +806,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = TokenExtension/TokenExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 107;
+				CURRENT_PROJECT_VERSION = 110;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				INFOPLIST_FILE = TokenExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
@@ -811,7 +815,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.3;
+				MARKETING_VERSION = 1.7.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yubico.Authenticator.TokenExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -945,7 +949,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Authenticator/Authenticator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 107;
+				CURRENT_PROJECT_VERSION = 110;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				HEADER_SEARCH_PATHS = "../Submodules/YubiKit/**";
 				INFOPLIST_FILE = Authenticator/Info.plist;
@@ -955,7 +959,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "";
-				MARKETING_VERSION = 1.7.3;
+				MARKETING_VERSION = 1.7.4;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yubico.Authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -973,7 +977,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Authenticator/Authenticator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 107;
+				CURRENT_PROJECT_VERSION = 110;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				HEADER_SEARCH_PATHS = "../Submodules/YubiKit/**";
 				INFOPLIST_FILE = Authenticator/Info.plist;
@@ -983,7 +987,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "";
-				MARKETING_VERSION = 1.7.3;
+				MARKETING_VERSION = 1.7.4;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yubico.Authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		5180974326DE185100A122C1 /* ResetOATHViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5180974226DE185100A122C1 /* ResetOATHViewModel.swift */; };
 		51A162862678A1F100C3FA1E /* OATHConfigurationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A162852678A1F100C3FA1E /* OATHConfigurationController.swift */; };
 		51AFD4D227103E36008F2630 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AFD4D127103E36008F2630 /* SearchBar.swift */; };
-		51AFD4D42716FC78008F2630 /* ApplicationSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AFD4D32716FC78008F2630 /* ApplicationSettingsController.swift */; };
+		51AFD4D42716FC78008F2630 /* NFCSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AFD4D32716FC78008F2630 /* NFCSettingsController.swift */; };
 		51AFD4D62716FCDB008F2630 /* ApplicationSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AFD4D52716FCDB008F2630 /* ApplicationSettingsViewModel.swift */; };
 		51AFD4D827196AB6008F2630 /* VersionHistory.plist in Resources */ = {isa = PBXBuildFile; fileRef = 51AFD4D727196AB6008F2630 /* VersionHistory.plist */; };
 		51AFD4DA271D4278008F2630 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51AFD4D9271D4277008F2630 /* QuartzCore.framework */; };
@@ -163,7 +163,7 @@
 		5180974226DE185100A122C1 /* ResetOATHViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetOATHViewModel.swift; sourceTree = "<group>"; };
 		51A162852678A1F100C3FA1E /* OATHConfigurationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OATHConfigurationController.swift; sourceTree = "<group>"; };
 		51AFD4D127103E36008F2630 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
-		51AFD4D32716FC78008F2630 /* ApplicationSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationSettingsController.swift; sourceTree = "<group>"; };
+		51AFD4D32716FC78008F2630 /* NFCSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCSettingsController.swift; sourceTree = "<group>"; };
 		51AFD4D52716FCDB008F2630 /* ApplicationSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationSettingsViewModel.swift; sourceTree = "<group>"; };
 		51AFD4D727196AB6008F2630 /* VersionHistory.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = VersionHistory.plist; sourceTree = "<group>"; };
 		51AFD4D9271D4277008F2630 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
@@ -272,7 +272,7 @@
 				A5D4E86C24083CF300FD63A0 /* OTPConfigurationController.swift */,
 				515542672654413600B19C59 /* SmartCardConfigurationController.swift */,
 				81FA3C31231AF289009C22AB /* SetPasswordViewController.swift */,
-				51AFD4D32716FC78008F2630 /* ApplicationSettingsController.swift */,
+				51AFD4D32716FC78008F2630 /* NFCSettingsController.swift */,
 			);
 			path = YubiKeyConfiguration;
 			sourceTree = "<group>";
@@ -703,7 +703,7 @@
 				515542682654413600B19C59 /* SmartCardConfigurationController.swift in Sources */,
 				5155428326569ADD00B19C59 /* UIControl+Extensions.swift in Sources */,
 				A544948F23CE546B003E1E07 /* TutorialPagesViewControllers.swift in Sources */,
-				51AFD4D42716FC78008F2630 /* ApplicationSettingsController.swift in Sources */,
+				51AFD4D42716FC78008F2630 /* NFCSettingsController.swift in Sources */,
 				51394C5C26D4D460009F366D /* MenuGestureRecognizer.swift in Sources */,
 				A5588BF9239B0A7F003E4CA5 /* FavoritesStorage.swift in Sources */,
 				B4B1711827DF8C48002A62DE /* ScanAccountView.swift in Sources */,

--- a/Authenticator/AppDelegate.swift
+++ b/Authenticator/AppDelegate.swift
@@ -82,9 +82,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         
         if let main = UIApplication.shared.windows.first?.rootViewController?.children.first as? OATHViewController {
-            if SettingsConfig.isCopyOTPEnabled, let url = userActivity.webpageURL {
+            if let url = userActivity.webpageURL {
+                var otp: String
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                if let fragment = components?.fragment {
+                    otp = fragment
+                } else {
+                    otp = url.lastPathComponent
+                }
                 main.dismiss(animated: false) {
-                    main.otp = url.lastPathComponent
+                    main.otp = otp
                 }
             }
             

--- a/Authenticator/AppDelegate.swift
+++ b/Authenticator/AppDelegate.swift
@@ -82,17 +82,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         
         if let main = UIApplication.shared.windows.first?.rootViewController?.children.first as? OATHViewController {
-            if SettingsConfig.isNFCOnOTPLaunchEnabled {
+            if SettingsConfig.isCopyOTPEnabled, let url = userActivity.webpageURL {
                 main.dismiss(animated: false) {
-                    main.refreshData()
+                    main.otp = url.lastPathComponent
                 }
             }
             
-            if SettingsConfig.isCopyOTPEnabled, let url = userActivity.webpageURL {
+            if SettingsConfig.isNFCOnOTPLaunchEnabled {
                 main.dismiss(animated: false) {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                        main.viewModel.copyToClipboard(value: url.lastPathComponent, message: "OTP copied to clipboard")
-                    }
+                    main.refreshData()
                 }
             }
         }

--- a/Authenticator/AppDelegate.swift
+++ b/Authenticator/AppDelegate.swift
@@ -77,6 +77,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         coder.encode(1.6, forKey: "AppVersion")
         return true
     }
+    
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        
+        if let main = UIApplication.shared.windows.first?.rootViewController?.children.first as? OATHViewController {
+            if SettingsConfig.isNFCOnOTPLaunchEnabled {
+                main.dismiss(animated: false) {
+                    main.refreshData()
+                }
+            }
+            
+            if SettingsConfig.isCopyOTPEnabled, let url = userActivity.webpageURL {
+                main.dismiss(animated: false) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                        main.viewModel.copyToClipboard(value: url.lastPathComponent, message: "OTP copied to clipboard")
+                    }
+                }
+            }
+        }
+
+        return true
+    }
 
     func application(_ application: UIApplication, shouldRestoreSecureApplicationState coder: NSCoder) -> Bool {
         let version = coder.decodeFloat(forKey: "AppVersion")

--- a/Authenticator/Authenticator.entitlements
+++ b/Authenticator/Authenticator.entitlements
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:my.yubico.com</string>
+		<string>applinks:dain.se</string>
+	</array>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
 		<string>TAG</string>

--- a/Authenticator/Authenticator.entitlements
+++ b/Authenticator/Authenticator.entitlements
@@ -5,7 +5,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:my.yubico.com</string>
-		<string>applinks:dain.se</string>
 	</array>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>

--- a/Authenticator/Model/ApplicationSettingsViewModel.swift
+++ b/Authenticator/Model/ApplicationSettingsViewModel.swift
@@ -35,4 +35,22 @@ struct ApplicationSettingsViewModel {
             SettingsConfig.isNFCOnAppLaunchEnabled = newValue
         }
     }
+    
+    var isNFCOnOTPLaunchEnabled: Bool {
+        get {
+            return SettingsConfig.isNFCOnOTPLaunchEnabled
+        }
+        set {
+            SettingsConfig.isNFCOnOTPLaunchEnabled = newValue
+        }
+    }
+    
+    var isCopyOTPEnabled: Bool {
+        get {
+            return SettingsConfig.isCopyOTPEnabled
+        }
+        set {
+            SettingsConfig.isCopyOTPEnabled = newValue
+        }
+    }
 }

--- a/Authenticator/Model/OATHViewModel.swift
+++ b/Authenticator/Model/OATHViewModel.swift
@@ -545,10 +545,10 @@ class OATHViewModel: NSObject, YKFManagerDelegate {
         self.delegate?.onOperationCompleted(operation: .filter)
     }
     
-    public func copyToClipboard(credential: Credential) {
+    public func copyToClipboard(value: String, message: String = "Copied to clipboard") {
         // copy to clipbboard
-        UIPasteboard.general.string = credential.code
-        self.delegate?.onShowToastMessage(message: "Copied to clipboard")
+        UIPasteboard.general.string = value
+        self.delegate?.onShowToastMessage(message: message)
     }
     
     public func emulateSomeRecords() {

--- a/Authenticator/Model/OATHViewModel.swift
+++ b/Authenticator/Model/OATHViewModel.swift
@@ -52,32 +52,39 @@ class OATHViewModel: NSObject, YKFManagerDelegate {
     
     private var nfcConnection: YKFNFCConnection?
     
-    private var lastNFCEndingTimestamp: Date?
-    
+    private var lastNFCStartTimestamp: Date?
+    private var lastNFCEndTimestamp: Date?
+
     var accessKeyMemoryCache = AccessKeyCache()
     let accessKeySecureStore = SecureStore(secureStoreQueryable: PasswordQueryable(service: "OATH"))
     let passwordPreferences = PasswordPreferences()
 
     var didNFCEndRecently: Bool {
-        guard let ts = lastNFCEndingTimestamp else { return false }
+        guard let ts = lastNFCEndTimestamp else { return false }
         return ts.addingTimeInterval(5) > Date()
+    }
+    
+    var didNFCStartRecently: Bool {
+        guard let ts = lastNFCStartTimestamp else { return false }
+        return ts.addingTimeInterval(2) > Date()
     }
     
     func didConnectNFC(_ connection: YKFNFCConnection) {
         nfcConnection = connection
+        lastNFCStartTimestamp = Date()
         if let callback = connectionCallback {
             callback(connection)
         }
     }
     
     func didDisconnectNFC(_ connection: YKFNFCConnection, error: Error?) {
-        lastNFCEndingTimestamp = Date()
+        lastNFCEndTimestamp = Date()
         nfcConnection = nil
         session = nil
     }
     
     func didFailConnectingNFC(_ error: Error) {
-        lastNFCEndingTimestamp = Date()
+        lastNFCEndTimestamp = Date()
     }
     
     private var accessoryConnection: YKFAccessoryConnection?

--- a/Authenticator/Model/SettingsConfig.swift
+++ b/Authenticator/Model/SettingsConfig.swift
@@ -30,7 +30,8 @@ class SettingsConfig {
     static private let showNFCSwipeHintCounter = "showNFCSwipeHintCounter"
     static private let showWhatsNewCounter = "showWhatsNewCounter"
     static private let showWhatsNewCounterAppVersion = "showWhatsNewCounterAppVersion"
-
+    static private let nfcOnOTPLaunch = "nfcOnOTPLaunch"
+    static private let copyOTP = "copyOTP"
     
     static var showWhatsNewText: Bool {
         get {
@@ -126,6 +127,24 @@ class SettingsConfig {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: nfcOnAppLaunch)
+        }
+    }
+    
+    static var isNFCOnOTPLaunchEnabled: Bool {
+        get {
+            return UserDefaults.standard.bool(forKey: nfcOnOTPLaunch)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: nfcOnOTPLaunch)
+        }
+    }
+    
+    static var isCopyOTPEnabled: Bool {
+        get {
+            return UserDefaults.standard.bool(forKey: copyOTP)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: copyOTP)
         }
     }
 }

--- a/Authenticator/Model/SettingsConfig.swift
+++ b/Authenticator/Model/SettingsConfig.swift
@@ -132,6 +132,10 @@ class SettingsConfig {
     
     static var isNFCOnOTPLaunchEnabled: Bool {
         get {
+            if UserDefaults.standard.object(forKey: nfcOnOTPLaunch) == nil {
+                UserDefaults.standard.set(true, forKey: nfcOnOTPLaunch)
+            }
+            
             return UserDefaults.standard.bool(forKey: nfcOnOTPLaunch)
         }
         set {

--- a/Authenticator/UI/Authentication/AddCredential/AddCredentialController.swift
+++ b/Authenticator/UI/Authentication/AddCredential/AddCredentialController.swift
@@ -89,7 +89,7 @@ class AddCredentialController: UITableViewController {
                 case .account(let account):
                     self.credential = account
                     self.mode = .prefilled
-                    updateWith(credential: account)
+                    self.updateWith(credential: account)
                 }
             }
             self.scanAccountView = scanAccountView

--- a/Authenticator/UI/Authentication/OATHCodeDetailsView.swift
+++ b/Authenticator/UI/Authentication/OATHCodeDetailsView.swift
@@ -138,7 +138,7 @@ class OATHCodeDetailsView: UIVisualEffectView {
         copyMenuAction = {
             MenuAction(title: "Copy", image: UIImage(systemName: "square.and.arrow.up"),
                        action: {
-                viewModel.copyToClipboard(credential: credential)
+                viewModel.copyToClipboard(value: credential.code)
             })
         }()
         

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -45,7 +45,7 @@ class OATHViewController: UITableViewController {
     
     var otp: String? = nil {
         didSet {
-            if let otp {
+            if let otp, SettingsConfig.isCopyOTPEnabled {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     self.viewModel.copyToClipboard(value: otp, message: "OTP copied to clipboard")
                 }

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -45,6 +45,7 @@ class OATHViewController: UITableViewController {
     
     var otp: String? = nil {
         didSet {
+            self.tableView.reloadData()
             if let otp, SettingsConfig.isCopyOTPEnabled {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     self.viewModel.copyToClipboard(value: otp, message: "OTP copied to clipboard")

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -43,6 +43,16 @@ class OATHViewController: UITableViewController {
     
     private var hintView: UIView?
     
+    var otp: String? = nil {
+        didSet {
+            if let otp {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    self.viewModel.copyToClipboard(value: otp, message: "OTP copied to clipboard")
+                }
+            }
+        }
+    }
+    
     private func setupMenu(enabled: Bool) {
         self.menuButton.menu = nil
         self.menuButton.menu = UIMenu(title: "", children: [
@@ -185,6 +195,8 @@ class OATHViewController: UITableViewController {
             sections = 2
         }
         
+        sections = otp != nil ? sections + 1 : sections
+        
         if sections > 0 {
             self.tableView.backgroundView = nil
             backgroundView = nil
@@ -209,11 +221,15 @@ class OATHViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        if viewModel.pinnedCredentials.count > 0 && section == 0 {
+        if otp != nil && section == 0 {
+            return "Yubico OTP"
+        }
+        
+        if viewModel.pinnedCredentials.count > 0 && (section == 0 || otp != nil && section == 1) {
             return "Pinned"
         }
         
-        if viewModel.pinnedCredentials.count == 0 && section == 0 {
+        if viewModel.pinnedCredentials.count == 0 && (section == 0 || otp != nil && section == 1) {
             return "Accounts"
         }
         
@@ -221,7 +237,12 @@ class OATHViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if section == 0 && viewModel.pinnedCredentials.count > 0 {
+        
+        if otp != nil && section == 0 {
+            return 1
+        }
+        
+        if (section == 0 || otp != nil && section == 1) && viewModel.pinnedCredentials.count > 0 {
             return viewModel.pinnedCredentials.count
         }
         
@@ -229,36 +250,42 @@ class OATHViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "CredentialCell", for: indexPath) as! CredentialTableViewCell
-        cell.viewModel = viewModel
-        let credential = credentialAt(indexPath)
-        cell.updateView(credential: credential)
         
-        let backgroundContainerView = UIView()
-        let backgroundView = UIView()
-        backgroundView.layer.cornerRadius = 10
-        backgroundView.backgroundColor = UIColor(named: "TableSelection")
-        backgroundView.translatesAutoresizingMaskIntoConstraints = false
-        backgroundContainerView.addSubview(backgroundView)
-        NSLayoutConstraint.activate([
-            backgroundView.leadingAnchor.constraint(equalTo: backgroundContainerView.leadingAnchor),
-            backgroundView.trailingAnchor.constraint(equalTo: backgroundContainerView.trailingAnchor),
-            backgroundView.topAnchor.constraint(equalTo: backgroundContainerView.topAnchor),
-            backgroundView.bottomAnchor.constraint(equalTo: backgroundContainerView.bottomAnchor)
-        ])
-        cell.selectedBackgroundView = backgroundContainerView
-        
-        return cell
+        if let credential = credentialAt(indexPath) {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "CredentialCell", for: indexPath) as! CredentialTableViewCell
+            cell.viewModel = viewModel
+            cell.updateView(credential: credential)
+            
+            let backgroundContainerView = UIView()
+            let backgroundView = UIView()
+            backgroundView.layer.cornerRadius = 10
+            backgroundView.backgroundColor = UIColor(named: "TableSelection")
+            backgroundView.translatesAutoresizingMaskIntoConstraints = false
+            backgroundContainerView.addSubview(backgroundView)
+            NSLayoutConstraint.activate([
+                backgroundView.leadingAnchor.constraint(equalTo: backgroundContainerView.leadingAnchor),
+                backgroundView.trailingAnchor.constraint(equalTo: backgroundContainerView.trailingAnchor),
+                backgroundView.topAnchor.constraint(equalTo: backgroundContainerView.topAnchor),
+                backgroundView.bottomAnchor.constraint(equalTo: backgroundContainerView.bottomAnchor)
+            ])
+            cell.selectedBackgroundView = backgroundContainerView
+            return cell
+        } else {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "OTPCell", for: indexPath) as! OTPTableViewCell
+            cell.otp.text = otp
+            return cell
+        }
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         _ = searchBar.resignFirstResponder()
-        let credential = credentialAt(indexPath)
-        let details = OATHCodeDetailsView(credential: credential, viewModel: viewModel, parentViewController: self)
-        let rect = tableView.rectForRow(at: indexPath)
-        details.present(from: CGPoint(x: rect.midX, y: rect.midY))
-        self.detailView = details
+        if let credential = credentialAt(indexPath) {
+            let details = OATHCodeDetailsView(credential: credential, viewModel: viewModel, parentViewController: self)
+            let rect = tableView.rectForRow(at: indexPath)
+            details.present(from: CGPoint(x: rect.midX, y: rect.midY))
+            self.detailView = details
+        }
     }
 
     // Override to support conditional editing of the table view.
@@ -309,26 +336,29 @@ class OATHViewController: UITableViewController {
         guard let indexPath = indexPath else {
             return
         }
-        let credential = credentialAt(indexPath)
         
         if UIDevice.current.userInterfaceIdiom == .phone {
             let generator = UINotificationFeedbackGenerator()
             generator.notificationOccurred(.success)
         }
 
-        if credential.requiresRefresh {
-            viewModel.calculate(credential: credential) { [self] _ in
-                DispatchQueue.main.async {
-                    let cell = self.tableView.cellForRow(at: indexPath) as? CredentialTableViewCell
-                    cell?.animateCode()
-
+        if let credential = credentialAt(indexPath) {
+            if credential.requiresRefresh {
+                viewModel.calculate(credential: credential) { [self] _ in
+                    DispatchQueue.main.async {
+                        let cell = self.tableView.cellForRow(at: indexPath) as? CredentialTableViewCell
+                        cell?.animateCode()
+                        
+                    }
+                    self.viewModel.copyToClipboard(value: credential.code)
                 }
-                self.viewModel.copyToClipboard(value: credential.code)
+            } else {
+                let cell = self.tableView.cellForRow(at: indexPath) as? CredentialTableViewCell
+                cell?.animateCode()
+                viewModel.copyToClipboard(value: credential.code)
             }
-        } else {
-            let cell = self.tableView.cellForRow(at: indexPath) as? CredentialTableViewCell
-            cell?.animateCode()
-            viewModel.copyToClipboard(value: credential.code)
+        } else if let otp = otp {
+            self.viewModel.copyToClipboard(value: otp, message: "OTP copied to clipboard")
         }
     }
     
@@ -605,8 +635,11 @@ extension OATHViewController: CredentialViewModelDelegate {
         }
     }
     
-    private func credentialAt(_ indexPath: IndexPath) -> Credential {
-        if viewModel.pinnedCredentials.count > 0 && indexPath.section == 0 {
+    private func credentialAt(_ indexPath: IndexPath) -> Credential? {
+        if otp != nil && indexPath.section == 0 {
+            return nil
+        }
+        if viewModel.pinnedCredentials.count > 0 && (indexPath.section == 0 || otp != nil && indexPath.section == 1) {
             return viewModel.pinnedCredentials[indexPath.row]
         } else {
             return viewModel.credentials[indexPath.row]
@@ -617,6 +650,7 @@ extension OATHViewController: CredentialViewModelDelegate {
 // MARK: ApplicationSessionObserverDelegate
 extension OATHViewController: ApplicationSessionObserverDelegate {
     func didEnterBackground() {
+        otp = nil
         viewModel.cleanUp()
     }
     

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -323,12 +323,12 @@ class OATHViewController: UITableViewController {
                     cell?.animateCode()
 
                 }
-                self.viewModel.copyToClipboard(credential: credential)
+                self.viewModel.copyToClipboard(value: credential.code)
             }
         } else {
             let cell = self.tableView.cellForRow(at: indexPath) as? CredentialTableViewCell
             cell?.animateCode()
-            viewModel.copyToClipboard(credential: credential)
+            viewModel.copyToClipboard(value: credential.code)
         }
     }
     

--- a/Authenticator/UI/Authentication/OATHViewController.swift
+++ b/Authenticator/UI/Authentication/OATHViewController.swift
@@ -383,8 +383,10 @@ class OATHViewController: UITableViewController {
     }
     
     @objc func refreshData() {
-        viewModel.calculateAll()
-        refreshControl?.endRefreshing()
+        if !viewModel.didNFCStartRecently {
+            viewModel.calculateAll()
+            refreshControl?.endRefreshing()
+        }
     }
     
     //

--- a/Authenticator/UI/Authentication/OTPTableViewCell.swift
+++ b/Authenticator/UI/Authentication/OTPTableViewCell.swift
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import UIKit
+import Combine
+
+class OTPTableViewCell: UITableViewCell {
+    
+    var viewModel: OATHViewModel!
+    
+    @IBOutlet weak var otp: UILabel!
+    @IBOutlet weak var icon: UIImageView!
+    
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        // Wait for the next runloop before setting the cornerRadius
+        DispatchQueue.main.async {
+            self.icon.layer.cornerRadius = self.icon.bounds.height / 2.0
+        }
+    }
+    
+}

--- a/Authenticator/UI/Base.lproj/Main.storyboard
+++ b/Authenticator/UI/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ews-nc-Pdd">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ews-nc-Pdd">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -202,7 +202,7 @@
             <objects>
                 <navigationController restorationIdentifier="RootNavigationController" id="ews-nc-Pdd" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="EZr-9j-3XK">
-                        <rect key="frame" x="0.0" y="47" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="50" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -252,7 +252,7 @@
             <objects>
                 <tableViewController restorationIdentifier="applicationSettings" id="IqS-lg-whJ" customClass="HelpViewController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="sHL-iT-zqk">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="tintColor" red="0.60500001910000001" green="0.79299998279999995" blue="0.23600000139999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="sectionIndexColor" red="0.60500001910000001" green="0.79299998279999995" blue="0.23600000139999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -482,7 +482,7 @@ All rights reserved.</string>
             <objects>
                 <tableViewController storyboardIdentifier="SetPasswordViewController" id="fE6-O1-wZU" customClass="SetPasswordViewController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="44" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="EbR-vz-nXg">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection footerTitle="For additional security and to prevent unauthorized access the YubiKey can be protected with a password" id="hOr-gJ-fIa">
@@ -637,7 +637,7 @@ All rights reserved.</string>
             <objects>
                 <tableViewController storyboardIdentifier="YubiKeyConfigurationConroller" id="aoN-t0-WPq" customClass="OTPConfigurationController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="Eeq-g4-NeJ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="tableFooterView" opaque="NO" contentMode="scaleToFill" id="ApK-64-tef">
                             <rect key="frame" x="0.0" y="266" width="375" height="208"/>
@@ -651,7 +651,7 @@ All rights reserved.</string>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Szl-yL-4ir">
-                                    <rect key="frame" x="20" y="170" width="335" height="30"/>
+                                    <rect key="frame" x="19" y="170" width="335" height="30"/>
                                     <state key="normal" title="UnwindButton"/>
                                     <connections>
                                         <segue destination="fSX-BI-gQd" kind="unwind" identifier="unwindToKeyConfiguration" unwindAction="unwindToKeyConfigurationWithSegue:" id="SFl-hQ-GJS"/>
@@ -777,7 +777,7 @@ All rights reserved.</string>
             <objects>
                 <tableViewController restorationIdentifier="yubikeyConfiguration" title="YubiKey configuration" id="09D-Aw-j1I" customClass="ConfigurationController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="aqu-ss-YQ6">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="tableHeaderView" contentMode="scaleToFill" id="E5g-yM-VxC">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="189"/>
@@ -819,17 +819,17 @@ All rights reserved.</string>
                             <tableViewSection headerTitle="INFORMATION" id="yed-kd-amP">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="y9d-ef-M2r">
-                                        <rect key="frame" x="20" y="244.33333206176758" width="335" height="133.66667175292969"/>
+                                        <rect key="frame" x="20" y="244.33333206176758" width="335" height="135"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="y9d-ef-M2r" id="N1J-CN-YzV">
-                                            <rect key="frame" x="0.0" y="0.0" width="335" height="134"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="335" height="135"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oEI-Vx-DRc">
-                                                    <rect key="frame" x="0.0" y="0.0" width="335" height="133.66666666666666"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="335" height="135"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KT1-7K-VIa" userLabel="Top content">
-                                                            <rect key="frame" x="0.0" y="0.0" width="335" height="66"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="335" height="66.666666666666671"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Device type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="llv-60-0FB">
                                                                     <rect key="frame" x="15" y="9.9999999999999982" width="90.333333333333329" height="20.333333333333329"/>
@@ -838,7 +838,7 @@ All rights reserved.</string>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VAw-dv-zeA">
-                                                                    <rect key="frame" x="15.000000000000002" y="35.333333333333336" width="27.666666666666671" height="20.666666666666664"/>
+                                                                    <rect key="frame" x="15.000000000000002" y="35.333333333333336" width="27.666666666666671" height="21.333333333333336"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -855,21 +855,21 @@ All rights reserved.</string>
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fdz-1b-reC" userLabel="Horizontal divider">
-                                                            <rect key="frame" x="0.0" y="66" width="335" height="1"/>
+                                                            <rect key="frame" x="0.0" y="66.666666666666671" width="335" height="1"/>
                                                             <color key="backgroundColor" systemColor="tertiarySystemFillColor"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="1" id="OaS-Ay-Lxr"/>
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5De-9k-ng0" userLabel="Vertical divider">
-                                                            <rect key="frame" x="167.66666666666666" y="67" width="1" height="66.666666666666686"/>
+                                                            <rect key="frame" x="167.66666666666666" y="67.666666666666686" width="1" height="67.333333333333314"/>
                                                             <color key="backgroundColor" systemColor="tertiarySystemFillColor"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="1" id="Oua-1j-Z26"/>
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dgO-iN-c0D" userLabel="Right content">
-                                                            <rect key="frame" x="168.66666666666663" y="67" width="166.33333333333337" height="66.666666666666686"/>
+                                                            <rect key="frame" x="168.66666666666663" y="67.666666666666686" width="166.33333333333337" height="67.333333333333314"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Serial number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lzm-p7-Lmb">
                                                                     <rect key="frame" x="14.999999999999993" y="9.9999999999999982" width="105.33333333333331" height="20.333333333333329"/>
@@ -878,7 +878,7 @@ All rights reserved.</string>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MBv-4M-eos">
-                                                                    <rect key="frame" x="15.000000000000002" y="36.333333333333329" width="27.666666666666671" height="20.333333333333329"/>
+                                                                    <rect key="frame" x="15.000000000000002" y="36.333333333333329" width="27.666666666666671" height="21"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -895,7 +895,7 @@ All rights reserved.</string>
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nGj-jJ-pPx" userLabel="Left content">
-                                                            <rect key="frame" x="0.0" y="67" width="167.66666666666666" height="66.666666666666686"/>
+                                                            <rect key="frame" x="0.0" y="67.666666666666686" width="167.66666666666666" height="67.333333333333314"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Firmware" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aFH-4H-WRy">
                                                                     <rect key="frame" x="15" y="9.9999999999999982" width="70" height="20.333333333333329"/>
@@ -904,7 +904,7 @@ All rights reserved.</string>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QGj-16-s0W">
-                                                                    <rect key="frame" x="15.000000000000002" y="36.333333333333329" width="27.666666666666671" height="20.333333333333329"/>
+                                                                    <rect key="frame" x="15.000000000000002" y="36.333333333333329" width="27.666666666666671" height="21"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -956,7 +956,7 @@ All rights reserved.</string>
                             <tableViewSection headerTitle="Configuration" id="C5n-jq-Mk9">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="uP5-O2-d0d" style="IBUITableViewCellStyleDefault" id="WD1-EX-IYQ" userLabel="Toggle One-Time password">
-                                        <rect key="frame" x="20" y="434.00000190734863" width="335" height="43.666667938232422"/>
+                                        <rect key="frame" x="20" y="435.33333015441895" width="335" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WD1-EX-IYQ" id="8u6-79-GWX">
                                             <rect key="frame" x="0.0" y="0.0" width="304.66666666666669" height="43.666667938232422"/>
@@ -976,7 +976,7 @@ All rights reserved.</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="03k-jY-TEC" style="IBUITableViewCellStyleDefault" id="AR8-8Z-HlN" userLabel="Passwords and reset">
-                                        <rect key="frame" x="20" y="477.66666984558105" width="335" height="43.666667938232422"/>
+                                        <rect key="frame" x="20" y="478.99999809265137" width="335" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AR8-8Z-HlN" id="TxQ-Ug-Vr0">
                                             <rect key="frame" x="0.0" y="0.0" width="304.66666666666669" height="43.666667938232422"/>
@@ -996,7 +996,7 @@ All rights reserved.</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="D3g-ds-RCu" style="IBUITableViewCellStyleDefault" id="svK-Xu-OrL" userLabel="Application settings">
-                                        <rect key="frame" x="20" y="521.33333778381348" width="335" height="43.666667938232422"/>
+                                        <rect key="frame" x="20" y="522.66666603088379" width="335" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="svK-Xu-OrL" id="qml-JJ-Spa">
                                             <rect key="frame" x="0.0" y="0.0" width="304.66666666666669" height="43.666667938232422"/>
@@ -1016,7 +1016,7 @@ All rights reserved.</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="iH3-4d-Rv5" detailTextLabel="9lL-ZS-odE" style="IBUITableViewCellStyleValue1" id="Uv3-td-07t" userLabel="Smart card extension">
-                                        <rect key="frame" x="20" y="565.0000057220459" width="335" height="43.666667938232422"/>
+                                        <rect key="frame" x="20" y="566.33333396911621" width="335" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Uv3-td-07t" id="UC4-yB-7i6">
                                             <rect key="frame" x="0.0" y="0.0" width="304.66666666666669" height="43.666667938232422"/>
@@ -1077,7 +1077,7 @@ All rights reserved.</string>
             <objects>
                 <tableViewController id="t28-TG-awK" customClass="SmartCardConfigurationController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="tmI-8c-SSH">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <connections>
                             <outlet property="dataSource" destination="t28-TG-awK" id="ZDa-4v-tvB"/>
@@ -1131,7 +1131,7 @@ All rights reserved.</string>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Orh-Ia-acz" userLabel="Accessory View">
-                                <rect key="frame" x="30" y="184" width="315" height="40"/>
+                                <rect key="frame" x="30" y="137" width="315" height="40"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insert a YubiKey and enter its PIN to access the certificate." lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="noy-hK-f0E">
                                         <rect key="frame" x="35" y="0.0" width="280" height="40"/>
@@ -1160,7 +1160,7 @@ All rights reserved.</string>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fhF-Zo-2iR" userLabel="PIN View">
-                                <rect key="frame" x="20" y="400.33333333333331" width="335" height="50"/>
+                                <rect key="frame" x="20" y="353.33333333333331" width="335" height="50"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Smart card (PIV) PIN" clearsOnBeginEditing="YES" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JON-gB-7WG">
                                         <rect key="frame" x="82.666666666666686" y="14" width="170" height="22"/>
@@ -1196,13 +1196,13 @@ All rights reserved.</string>
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unlock YubiKey" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O2N-dk-eMF">
-                                <rect key="frame" x="113" y="117" width="149" height="27"/>
+                                <rect key="frame" x="113" y="70" width="149" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LUC-vU-Hsv">
-                                <rect key="frame" x="30" y="284" width="315" height="56.333333333333314"/>
+                                <rect key="frame" x="30" y="237.00000000000003" width="315" height="56.333333333333343"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter the PIN, then tap a NFC enabled YubiKey against the iPhone to access the certificate." lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WGy-0e-K7w">
                                         <rect key="frame" x="35" y="0.0" width="280" height="57.333333333333336"/>
@@ -1228,7 +1228,7 @@ All rights reserved.</string>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uEK-pP-paH">
-                                <rect key="frame" x="20" y="239" width="335" height="30"/>
+                                <rect key="frame" x="20" y="192" width="335" height="30"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pD5-QU-h4Q">
                                         <rect key="frame" x="0.0" y="14.666666666666657" width="335" height="1"/>
@@ -1268,7 +1268,7 @@ All rights reserved.</string>
                                         <color key="tintColor" name="Color11"/>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Tap the back button to continue" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-HU-1WC">
-                                        <rect key="frame" x="75" y="334" width="231" height="20"/>
+                                        <rect key="frame" x="74" y="334" width="231" height="20"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <nil key="textColor"/>
@@ -1328,7 +1328,7 @@ All rights reserved.</string>
             <objects>
                 <tableViewController restorationIdentifier="oathConfiguration" title="YubiKey configuration" id="Bxb-bg-K32" userLabel="OATH configuration" customClass="OATHConfigurationController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="NBV-rD-K8D">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection id="xhs-96-o3m">
@@ -1417,7 +1417,7 @@ All rights reserved.</string>
                             <tableViewSection headerTitle="" footerTitle="" id="a4m-Y3-hnM">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="PYZ-Wa-hkr" userLabel="Header">
-                                        <rect key="frame" x="20" y="345.00000190734863" width="335" height="192"/>
+                                        <rect key="frame" x="20" y="345.00000190734858" width="335" height="192.00000000000006"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PYZ-Wa-hkr" id="kmi-YO-gZK">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="192"/>
@@ -1558,138 +1558,185 @@ All rights reserved.</string>
         <!--Applications Settings-->
         <scene sceneID="t0d-DJ-jHa">
             <objects>
-                <tableViewController storyboardIdentifier="YubiKeyApplicationSettings" id="zNg-aX-Qai" userLabel="Applications Settings" customClass="ApplicationSettingsController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="YubiKeyApplicationSettings" id="zNg-aX-Qai" userLabel="Applications Settings" customClass="NFCSettingsController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="622-iz-rgS">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="tableFooterView" opaque="NO" contentMode="scaleToFill" id="wGK-Gb-ggw">
-                            <rect key="frame" x="0.0" y="394" width="375" height="208"/>
+                            <rect key="frame" x="0.0" y="482.66666603088379" width="375" height="208"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <sections>
-                            <tableViewSection footerTitle="" id="aEM-wq-dyj">
+                            <tableViewSection footerTitle="Initiate NFC at application start will automatically read your YubiKey as soon as the app becomes active." id="gQR-ie-6Y0">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="dZ3-Vl-nTP">
-                                        <rect key="frame" x="20" y="18" width="335" height="265"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="8bq-0Q-S5P">
+                                        <rect key="frame" x="20" y="18" width="335" height="44.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dZ3-Vl-nTP" id="bpL-Sn-hbb">
-                                            <rect key="frame" x="0.0" y="0.0" width="335" height="265"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iphone.radiowaves.left.and.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="WL3-IB-Clb">
-                                                    <rect key="frame" x="135" y="21.000000000000004" width="65" height="53.333333333333343"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="55" id="Hsp-XO-vlc"/>
-                                                        <constraint firstAttribute="width" constant="65" id="vl5-0E-cbo"/>
-                                                    </constraints>
-                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="70"/>
-                                                </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NFC USER EXPERIENCE" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UJe-A6-udG">
-                                                    <rect key="frame" x="10" y="90" width="315" height="20.333333333333329"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zL7-OO-oMR">
-                                                    <rect key="frame" x="10" y="120.33333333333331" width="315" height="124.66666666666669"/>
-                                                    <string key="text">Accounts that require touch will need an extra NFC tap to calculate its code. Bypassing it minimizes the number of NFC taps needed. Initiate NFC at application start will automatically read your YubiKey as soon as the app becomes active.</string>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="WL3-IB-Clb" firstAttribute="top" secondItem="bpL-Sn-hbb" secondAttribute="top" constant="20" id="Auv-Go-wcy"/>
-                                                <constraint firstAttribute="trailing" secondItem="zL7-OO-oMR" secondAttribute="trailing" constant="10" id="B53-bd-v0l"/>
-                                                <constraint firstItem="UJe-A6-udG" firstAttribute="leading" secondItem="bpL-Sn-hbb" secondAttribute="leading" constant="10" id="Tgk-BF-hbU"/>
-                                                <constraint firstAttribute="trailing" secondItem="UJe-A6-udG" secondAttribute="trailing" constant="10" id="U6A-mF-mrX"/>
-                                                <constraint firstItem="UJe-A6-udG" firstAttribute="top" secondItem="WL3-IB-Clb" secondAttribute="bottom" constant="15" id="Yxq-vm-kCp"/>
-                                                <constraint firstItem="WL3-IB-Clb" firstAttribute="centerX" secondItem="bpL-Sn-hbb" secondAttribute="centerX" id="c5i-wP-3Wn"/>
-                                                <constraint firstItem="zL7-OO-oMR" firstAttribute="top" secondItem="UJe-A6-udG" secondAttribute="bottom" constant="10" id="ckA-K2-a0d"/>
-                                                <constraint firstAttribute="bottom" secondItem="zL7-OO-oMR" secondAttribute="bottom" constant="20" id="fYW-j0-WPI"/>
-                                                <constraint firstItem="zL7-OO-oMR" firstAttribute="leading" secondItem="bpL-Sn-hbb" secondAttribute="leading" constant="10" id="hib-rh-AKw"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <accessibility key="accessibilityConfiguration">
-                                            <accessibilityTraits key="traits" notEnabled="YES"/>
-                                        </accessibility>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Fxo-Rh-res">
-                                        <rect key="frame" x="20" y="283" width="335" height="44.666667938232422"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Fxo-Rh-res" id="V9R-gk-MEL">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8bq-0Q-S5P" id="pZV-b5-wF2">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="44.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="6mY-CW-sVF">
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="mzD-Gq-DDl">
                                                     <rect key="frame" x="20" y="-3" width="295" height="50.666666666666664"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bypass touch requirement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J5h-I7-OhT">
-                                                            <rect key="frame" x="0.0" y="0.0" width="231" height="50.666666666666664"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Initiate NFC at application start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Efl-xJ-qER">
+                                                            <rect key="frame" x="0.0" y="15.333333333333334" width="234.33333333333334" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GS6-m1-s05">
-                                                            <rect key="frame" x="246" y="9.6666666666666696" width="51" height="31.333333333333329"/>
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z4u-GU-EoJ">
+                                                            <rect key="frame" x="249.33333333333329" y="9.6666666666666696" width="47.666666666666657" height="31.333333333333329"/>
                                                             <color key="onTintColor" name="YubiBlue"/>
                                                             <connections>
-                                                                <action selector="changeBypassTouchSetting:" destination="zNg-aX-Qai" eventType="valueChanged" id="HCC-I5-Oia"/>
+                                                                <action selector="changeNFCOnAppLaunchSetting:" destination="zNg-aX-Qai" eventType="valueChanged" id="4fJ-TW-TU5"/>
                                                             </connections>
                                                         </switch>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstItem="GS6-m1-s05" firstAttribute="top" secondItem="6mY-CW-sVF" secondAttribute="top" constant="9.6666666666666679" id="X7q-Ao-c8U"/>
-                                                        <constraint firstItem="J5h-I7-OhT" firstAttribute="top" secondItem="6mY-CW-sVF" secondAttribute="topMargin" id="mBL-aJ-Lp5"/>
+                                                        <constraint firstItem="z4u-GU-EoJ" firstAttribute="top" secondItem="mzD-Gq-DDl" secondAttribute="top" constant="9.6666666666666679" id="DCR-xf-GtE"/>
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="6mY-CW-sVF" firstAttribute="top" secondItem="V9R-gk-MEL" secondAttribute="topMargin" constant="-14" id="CNJ-Ot-yfh"/>
-                                                <constraint firstItem="6mY-CW-sVF" firstAttribute="leading" secondItem="V9R-gk-MEL" secondAttribute="leadingMargin" id="QgH-6L-dYO"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="6mY-CW-sVF" secondAttribute="trailing" id="d07-TG-r47"/>
-                                                <constraint firstItem="6mY-CW-sVF" firstAttribute="centerY" secondItem="V9R-gk-MEL" secondAttribute="centerY" id="nk0-cZ-1B7"/>
+                                                <constraint firstItem="mzD-Gq-DDl" firstAttribute="leading" secondItem="pZV-b5-wF2" secondAttribute="leadingMargin" id="941-bb-txv"/>
+                                                <constraint firstItem="mzD-Gq-DDl" firstAttribute="centerY" secondItem="pZV-b5-wF2" secondAttribute="centerY" id="ACf-nK-WZg"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="mzD-Gq-DDl" secondAttribute="trailing" id="O1D-w5-iPq"/>
+                                                <constraint firstItem="mzD-Gq-DDl" firstAttribute="top" secondItem="pZV-b5-wF2" secondAttribute="topMargin" constant="-14" id="vCy-lI-9Nc"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" notEnabled="YES"/>
                                         </accessibility>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="SUl-Xj-Oyq">
-                                        <rect key="frame" x="20" y="327.66666793823242" width="335" height="44.666667938232422"/>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="Uvq-Ba-xiH">
+                                <string key="footerTitle">Accounts that require touch will need an extra NFC tap to calculate its code. Bypassing it minimizes the number of NFC taps needed.</string>
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="YeE-yN-d6Q">
+                                        <rect key="frame" x="20" y="142.66666603088379" width="335" height="44.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SUl-Xj-Oyq" id="RkF-pa-HpI">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="YeE-yN-d6Q" id="zfQ-Td-vWJ">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="44.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="mSk-r5-m2R">
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="HFa-lp-4jd">
                                                     <rect key="frame" x="20" y="-3" width="295" height="50.666666666666664"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Initiate NFC at application start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f7Z-Xf-ZVS">
-                                                            <rect key="frame" x="0.0" y="0.0" width="234.33333333333334" height="50.666666666666664"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bypass touch requirement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="frN-Of-d1s">
+                                                            <rect key="frame" x="0.0" y="15.333333333333334" width="231" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GGb-4H-vL3">
-                                                            <rect key="frame" x="249.33333333333329" y="9.6666666666666696" width="47.666666666666657" height="31.333333333333329"/>
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fuy-PU-CzD">
+                                                            <rect key="frame" x="246" y="9.6666666666666696" width="51" height="31.333333333333329"/>
                                                             <color key="onTintColor" name="YubiBlue"/>
                                                             <connections>
-                                                                <action selector="changeNFCOnAppLaunchSetting:" destination="zNg-aX-Qai" eventType="valueChanged" id="yaa-sq-f1V"/>
+                                                                <action selector="changeBypassTouchSetting:" destination="zNg-aX-Qai" eventType="valueChanged" id="xDG-VS-RVN"/>
                                                             </connections>
                                                         </switch>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstItem="f7Z-Xf-ZVS" firstAttribute="top" secondItem="mSk-r5-m2R" secondAttribute="topMargin" id="7nH-IE-PHC"/>
-                                                        <constraint firstItem="GGb-4H-vL3" firstAttribute="top" secondItem="mSk-r5-m2R" secondAttribute="top" constant="9.6666666666666679" id="odY-Vi-4Tr"/>
+                                                        <constraint firstItem="Fuy-PU-CzD" firstAttribute="top" secondItem="HFa-lp-4jd" secondAttribute="top" constant="9.6666666666666679" id="0ub-bY-hZV"/>
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="mSk-r5-m2R" firstAttribute="leading" secondItem="RkF-pa-HpI" secondAttribute="leadingMargin" id="2rN-q0-rJF"/>
-                                                <constraint firstItem="mSk-r5-m2R" firstAttribute="top" secondItem="RkF-pa-HpI" secondAttribute="topMargin" constant="-14" id="7ZU-Eu-9JL"/>
-                                                <constraint firstItem="mSk-r5-m2R" firstAttribute="centerY" secondItem="RkF-pa-HpI" secondAttribute="centerY" id="A9F-mZ-bZ7"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="mSk-r5-m2R" secondAttribute="trailing" id="XFS-pk-Qml"/>
+                                                <constraint firstItem="HFa-lp-4jd" firstAttribute="top" secondItem="zfQ-Td-vWJ" secondAttribute="topMargin" constant="-14" id="Fec-v8-I9h"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="HFa-lp-4jd" secondAttribute="trailing" id="YnY-cp-smG"/>
+                                                <constraint firstItem="HFa-lp-4jd" firstAttribute="centerY" secondItem="zfQ-Td-vWJ" secondAttribute="centerY" id="dw7-8M-WTM"/>
+                                                <constraint firstItem="HFa-lp-4jd" firstAttribute="leading" secondItem="zfQ-Td-vWJ" secondAttribute="leadingMargin" id="sWy-jC-Vq8"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <accessibilityTraits key="traits" notEnabled="YES"/>
+                                        </accessibility>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection footerTitle="Start NFC and read OATH accounts when the application has been opened by reading the OTP tag on a YubiKey." id="JSq-rh-zB3">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="xLu-6A-op7">
+                                        <rect key="frame" x="20" y="267.33333206176758" width="335" height="44.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xLu-6A-op7" id="J6T-hD-CK4">
+                                            <rect key="frame" x="0.0" y="0.0" width="335" height="44.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="2fV-hk-Nye">
+                                                    <rect key="frame" x="20" y="-3" width="295" height="50.666666666666664"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Initiate NFC on OTP tag read" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Byl-RD-bpD">
+                                                            <rect key="frame" x="0.0" y="15.333333333333334" width="231" height="20.333333333333329"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c18-iq-7YH">
+                                                            <rect key="frame" x="246" y="9.6666666666666696" width="51" height="31.333333333333329"/>
+                                                            <color key="onTintColor" name="YubiBlue"/>
+                                                            <connections>
+                                                                <action selector="changeNFCOnOTPLaunchSetting:" destination="zNg-aX-Qai" eventType="valueChanged" id="WBq-KH-VXU"/>
+                                                            </connections>
+                                                        </switch>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="c18-iq-7YH" firstAttribute="top" secondItem="2fV-hk-Nye" secondAttribute="top" constant="9.6666666666666679" id="e1y-kN-bSs"/>
+                                                    </constraints>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="2fV-hk-Nye" firstAttribute="leading" secondItem="J6T-hD-CK4" secondAttribute="leadingMargin" id="LHc-3D-VZo"/>
+                                                <constraint firstItem="2fV-hk-Nye" firstAttribute="top" secondItem="J6T-hD-CK4" secondAttribute="topMargin" constant="-14" id="Une-wF-FUu"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="2fV-hk-Nye" secondAttribute="trailing" id="cWg-Bh-HdV"/>
+                                                <constraint firstItem="2fV-hk-Nye" firstAttribute="centerY" secondItem="J6T-hD-CK4" secondAttribute="centerY" id="tyO-qz-Tk7"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <accessibilityTraits key="traits" notEnabled="YES"/>
+                                        </accessibility>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection footerTitle="Copy OTP to clipboard when a YubiKey has been scanned using the NFC tag functionality." id="oy6-QK-Bgw">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Jey-gn-Ds9">
+                                        <rect key="frame" x="20" y="391.99999809265137" width="335" height="44.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Jey-gn-Ds9" id="dq0-Qu-GIJ">
+                                            <rect key="frame" x="0.0" y="0.0" width="335" height="44.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="olr-cT-8VC">
+                                                    <rect key="frame" x="20" y="-3" width="295" height="50.666666666666664"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Copy OTP to clipboard" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hsz-tV-DPW">
+                                                            <rect key="frame" x="0.0" y="15.333333333333334" width="231" height="20.333333333333329"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jjo-aP-iV6">
+                                                            <rect key="frame" x="246" y="9.6666666666666696" width="51" height="31.333333333333329"/>
+                                                            <color key="onTintColor" name="YubiBlue"/>
+                                                            <connections>
+                                                                <action selector="changeCopyOTPSetting:" destination="zNg-aX-Qai" eventType="valueChanged" id="95g-Qd-yhw"/>
+                                                            </connections>
+                                                        </switch>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="Jjo-aP-iV6" firstAttribute="top" secondItem="olr-cT-8VC" secondAttribute="top" constant="9.6666666666666679" id="vCG-2j-6dO"/>
+                                                    </constraints>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="olr-cT-8VC" secondAttribute="trailing" id="OWB-RO-lx0"/>
+                                                <constraint firstItem="olr-cT-8VC" firstAttribute="centerY" secondItem="dq0-Qu-GIJ" secondAttribute="centerY" id="OXV-nO-7xH"/>
+                                                <constraint firstItem="olr-cT-8VC" firstAttribute="top" secondItem="dq0-Qu-GIJ" secondAttribute="topMargin" constant="-14" id="QAm-hY-UHq"/>
+                                                <constraint firstItem="olr-cT-8VC" firstAttribute="leading" secondItem="dq0-Qu-GIJ" secondAttribute="leadingMargin" id="cfh-kS-9T1"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <accessibility key="accessibilityConfiguration">
@@ -1702,8 +1749,10 @@ All rights reserved.</string>
                     </tableView>
                     <navigationItem key="navigationItem" title="NFC settings" id="PCq-PC-KyX"/>
                     <connections>
-                        <outlet property="bypassTouchSwitch" destination="GS6-m1-s05" id="SRM-On-KFX"/>
-                        <outlet property="nfcOnAppLaunchSwitch" destination="GGb-4H-vL3" id="J3u-Bg-Jdo"/>
+                        <outlet property="bypassTouchSwitch" destination="Fuy-PU-CzD" id="JRt-G1-l5M"/>
+                        <outlet property="copyOTPSwitch" destination="Jjo-aP-iV6" id="OSd-G7-Rk5"/>
+                        <outlet property="nfcOnAppLaunchSwitch" destination="z4u-GU-EoJ" id="Kji-d1-uCR"/>
+                        <outlet property="nfcOnOTPLaunchSwitch" destination="c18-iq-7YH" id="2Pt-pN-kH9"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bfm-XY-LRn" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1725,7 +1774,6 @@ All rights reserved.</string>
         <image name="ellipsis.rectangle" catalog="system" width="128" height="79"/>
         <image name="icon" width="60" height="60"/>
         <image name="iphone" catalog="system" width="112" height="128"/>
-        <image name="iphone.radiowaves.left.and.right" catalog="system" width="128" height="85"/>
         <image name="magnifyingglass.circle" catalog="system" width="128" height="123"/>
         <image name="questionmark.circle" catalog="system" width="128" height="123"/>
         <image name="xmark.circle" catalog="system" width="128" height="123"/>

--- a/Authenticator/UI/Base.lproj/Main.storyboard
+++ b/Authenticator/UI/Base.lproj/Main.storyboard
@@ -176,7 +176,7 @@
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jJS-da-ceS">
                                             <rect key="frame" x="20" y="3" width="38" height="38"/>
                                             <color key="backgroundColor" name="YubiGreen"/>
-                                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="tintColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="38" id="EKV-5A-K6F"/>
                                                 <constraint firstAttribute="height" constant="38" id="Kzt-q2-rTA"/>
@@ -683,7 +683,7 @@ All rights reserved.</string>
                         <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="tableFooterView" opaque="NO" contentMode="scaleToFill" id="ApK-64-tef">
-                            <rect key="frame" x="0.0" y="265.66666793823242" width="375" height="208"/>
+                            <rect key="frame" x="0.0" y="266" width="375" height="208"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="WaV-Pv-SDy">
@@ -1606,7 +1606,7 @@ All rights reserved.</string>
                         <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="tableFooterView" opaque="NO" contentMode="scaleToFill" id="wGK-Gb-ggw">
-                            <rect key="frame" x="0.0" y="481.66666603088379" width="375" height="208"/>
+                            <rect key="frame" x="0.0" y="498" width="375" height="208"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
@@ -1740,7 +1740,7 @@ All rights reserved.</string>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection footerTitle="Copy OTP to clipboard when a YubiKey has been scanned using the NFC tag functionality." id="oy6-QK-Bgw">
+                            <tableViewSection footerTitle="Copy OTP automatically to clipboard when a YubiKey has been scanned using the NFC tag functionality." id="oy6-QK-Bgw">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Jey-gn-Ds9">
                                         <rect key="frame" x="20" y="390.99999809265137" width="335" height="44.666667938232422"/>

--- a/Authenticator/UI/Base.lproj/Main.storyboard
+++ b/Authenticator/UI/Base.lproj/Main.storyboard
@@ -166,6 +166,48 @@
                                     <outlet property="progressScalingConstraint" destination="ejz-nk-Qkq" id="H5M-Z8-MPf"/>
                                 </connections>
                             </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="OTPCell" id="b1I-Hv-jNy" customClass="OTPTableViewCell" customModule="Authenticator" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="104" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="b1I-Hv-jNy" id="mHL-1B-etO">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jJS-da-ceS">
+                                            <rect key="frame" x="20" y="0.0" width="38" height="38"/>
+                                            <color key="backgroundColor" name="YubiGreen"/>
+                                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="38" id="Kzt-q2-rTA"/>
+                                                <constraint firstAttribute="width" secondItem="jJS-da-ceS" secondAttribute="height" multiplier="1:1" id="sRA-eC-sv3"/>
+                                            </constraints>
+                                            <imageReference key="image" image="yubikey" symbolScale="large" renderingMode="template"/>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                    <real key="value" value="5"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U1p-Q4-Gp9">
+                                            <rect key="frame" x="69" y="11" width="290" height="21"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="U1p-Q4-Gp9" secondAttribute="trailing" constant="20" id="GRW-2h-FlX"/>
+                                        <constraint firstItem="U1p-Q4-Gp9" firstAttribute="leading" secondItem="jJS-da-ceS" secondAttribute="trailing" constant="10" id="V76-gv-rWz"/>
+                                        <constraint firstItem="U1p-Q4-Gp9" firstAttribute="centerY" secondItem="mHL-1B-etO" secondAttribute="centerY" id="dNV-M0-M7N"/>
+                                        <constraint firstItem="jJS-da-ceS" firstAttribute="leading" secondItem="mHL-1B-etO" secondAttribute="leading" constant="20" id="uha-cC-QxJ"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <color key="backgroundColor" name="CustomTableBackgroundColor"/>
+                                <connections>
+                                    <outlet property="icon" destination="jJS-da-ceS" id="Qv6-fX-gfR"/>
+                                    <outlet property="otp" destination="U1p-Q4-Gp9" id="RvM-Np-6A8"/>
+                                </connections>
+                            </tableViewCell>
                         </prototypes>
                         <connections>
                             <outlet property="dataSource" destination="r4m-OO-XO1" id="3yY-s6-gZN"/>
@@ -640,7 +682,7 @@ All rights reserved.</string>
                         <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="tableFooterView" opaque="NO" contentMode="scaleToFill" id="ApK-64-tef">
-                            <rect key="frame" x="0.0" y="266" width="375" height="208"/>
+                            <rect key="frame" x="0.0" y="265.66666793823242" width="375" height="208"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="WaV-Pv-SDy">
@@ -1417,7 +1459,7 @@ All rights reserved.</string>
                             <tableViewSection headerTitle="" footerTitle="" id="a4m-Y3-hnM">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="PYZ-Wa-hkr" userLabel="Header">
-                                        <rect key="frame" x="20" y="345.00000190734858" width="335" height="192.00000000000006"/>
+                                        <rect key="frame" x="20" y="345.00000190734863" width="335" height="192"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PYZ-Wa-hkr" id="kmi-YO-gZK">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="192"/>
@@ -1669,7 +1711,7 @@ All rights reserved.</string>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="2fV-hk-Nye">
                                                     <rect key="frame" x="20" y="-3" width="295" height="50.666666666666664"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Initiate NFC on OTP tag read" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Byl-RD-bpD">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start NFC on OTP tag read" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Byl-RD-bpD">
                                                             <rect key="frame" x="0.0" y="15.333333333333334" width="231" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
@@ -1761,7 +1803,7 @@ All rights reserved.</string>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="UPN-tw-Bce"/>
+        <segue reference="0dB-Xx-crT"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" name="YubiBlue"/>
     <resources>
@@ -1789,6 +1831,9 @@ All rights reserved.</string>
         </namedColor>
         <namedColor name="YubiBlue">
             <color red="0.19599999487400055" green="0.37299999594688416" blue="0.45500001311302185" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="YubiGreen">
+            <color red="0.64300000667572021" green="0.80800002813339233" blue="0.41600000858306885" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
         <systemColor name="labelColor">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Authenticator/UI/Base.lproj/Main.storyboard
+++ b/Authenticator/UI/Base.lproj/Main.storyboard
@@ -173,13 +173,13 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jJS-da-ceS">
-                                            <rect key="frame" x="20" y="0.0" width="38" height="38"/>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jJS-da-ceS">
+                                            <rect key="frame" x="20" y="3" width="38" height="38"/>
                                             <color key="backgroundColor" name="YubiGreen"/>
                                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
+                                                <constraint firstAttribute="width" constant="38" id="EKV-5A-K6F"/>
                                                 <constraint firstAttribute="height" constant="38" id="Kzt-q2-rTA"/>
-                                                <constraint firstAttribute="width" secondItem="jJS-da-ceS" secondAttribute="height" multiplier="1:1" id="sRA-eC-sv3"/>
                                             </constraints>
                                             <imageReference key="image" image="yubikey" symbolScale="large" renderingMode="template"/>
                                             <userDefinedRuntimeAttributes>
@@ -188,18 +188,19 @@
                                                 </userDefinedRuntimeAttribute>
                                             </userDefinedRuntimeAttributes>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U1p-Q4-Gp9">
-                                            <rect key="frame" x="69" y="11" width="290" height="21"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="vvcccctrjkcngnfbfkkhdikhl..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U1p-Q4-Gp9">
+                                            <rect key="frame" x="68" y="10" width="277" height="24"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="trailing" secondItem="U1p-Q4-Gp9" secondAttribute="trailing" constant="20" id="GRW-2h-FlX"/>
+                                        <constraint firstAttribute="trailing" secondItem="U1p-Q4-Gp9" secondAttribute="trailing" constant="30" id="GRW-2h-FlX"/>
                                         <constraint firstItem="U1p-Q4-Gp9" firstAttribute="leading" secondItem="jJS-da-ceS" secondAttribute="trailing" constant="10" id="V76-gv-rWz"/>
                                         <constraint firstItem="U1p-Q4-Gp9" firstAttribute="centerY" secondItem="mHL-1B-etO" secondAttribute="centerY" id="dNV-M0-M7N"/>
                                         <constraint firstItem="jJS-da-ceS" firstAttribute="leading" secondItem="mHL-1B-etO" secondAttribute="leading" constant="20" id="uha-cC-QxJ"/>
+                                        <constraint firstItem="jJS-da-ceS" firstAttribute="centerY" secondItem="mHL-1B-etO" secondAttribute="centerY" id="yd5-R4-vT4"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <color key="backgroundColor" name="CustomTableBackgroundColor"/>
@@ -1459,7 +1460,7 @@ All rights reserved.</string>
                             <tableViewSection headerTitle="" footerTitle="" id="a4m-Y3-hnM">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="PYZ-Wa-hkr" userLabel="Header">
-                                        <rect key="frame" x="20" y="345.00000190734863" width="335" height="192"/>
+                                        <rect key="frame" x="20" y="345.00000190734858" width="335" height="192.00000000000006"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PYZ-Wa-hkr" id="kmi-YO-gZK">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="192"/>
@@ -1605,7 +1606,7 @@ All rights reserved.</string>
                         <rect key="frame" x="0.0" y="0.0" width="375" height="802"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="tableFooterView" opaque="NO" contentMode="scaleToFill" id="wGK-Gb-ggw">
-                            <rect key="frame" x="0.0" y="482.66666603088379" width="375" height="208"/>
+                            <rect key="frame" x="0.0" y="481.66666603088379" width="375" height="208"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
@@ -1613,39 +1614,35 @@ All rights reserved.</string>
                             <tableViewSection footerTitle="Initiate NFC at application start will automatically read your YubiKey as soon as the app becomes active." id="gQR-ie-6Y0">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="8bq-0Q-S5P">
-                                        <rect key="frame" x="20" y="18" width="335" height="44.666667938232422"/>
+                                        <rect key="frame" x="20" y="18" width="335" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8bq-0Q-S5P" id="pZV-b5-wF2">
-                                            <rect key="frame" x="0.0" y="0.0" width="335" height="44.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="335" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="mzD-Gq-DDl">
-                                                    <rect key="frame" x="20" y="-3" width="295" height="50.666666666666664"/>
+                                                    <rect key="frame" x="16.666666666666657" y="6.3333333333333321" width="298.33333333333337" height="30.999999999999996"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Initiate NFC at application start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Efl-xJ-qER">
-                                                            <rect key="frame" x="0.0" y="15.333333333333334" width="234.33333333333334" height="20.333333333333329"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Initiate NFC at application start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Efl-xJ-qER">
+                                                            <rect key="frame" x="0.0" y="5.3333333333333339" width="234.33333333333334" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z4u-GU-EoJ">
-                                                            <rect key="frame" x="249.33333333333329" y="9.6666666666666696" width="47.666666666666657" height="31.333333333333329"/>
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z4u-GU-EoJ">
+                                                            <rect key="frame" x="249.33333333333337" y="0.0" width="51" height="31"/>
                                                             <color key="onTintColor" name="YubiBlue"/>
                                                             <connections>
                                                                 <action selector="changeNFCOnAppLaunchSetting:" destination="zNg-aX-Qai" eventType="valueChanged" id="4fJ-TW-TU5"/>
                                                             </connections>
                                                         </switch>
                                                     </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="z4u-GU-EoJ" firstAttribute="top" secondItem="mzD-Gq-DDl" secondAttribute="top" constant="9.6666666666666679" id="DCR-xf-GtE"/>
-                                                    </constraints>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="mzD-Gq-DDl" firstAttribute="leading" secondItem="pZV-b5-wF2" secondAttribute="leadingMargin" id="941-bb-txv"/>
                                                 <constraint firstItem="mzD-Gq-DDl" firstAttribute="centerY" secondItem="pZV-b5-wF2" secondAttribute="centerY" id="ACf-nK-WZg"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="mzD-Gq-DDl" secondAttribute="trailing" id="O1D-w5-iPq"/>
-                                                <constraint firstItem="mzD-Gq-DDl" firstAttribute="top" secondItem="pZV-b5-wF2" secondAttribute="topMargin" constant="-14" id="vCy-lI-9Nc"/>
+                                                <constraint firstItem="Efl-xJ-qER" firstAttribute="leading" secondItem="pZV-b5-wF2" secondAttribute="leading" constant="16.666666666666657" id="iU9-Wo-LKj"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <accessibility key="accessibilityConfiguration">
@@ -1658,7 +1655,7 @@ All rights reserved.</string>
                                 <string key="footerTitle">Accounts that require touch will need an extra NFC tap to calculate its code. Bypassing it minimizes the number of NFC taps needed.</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="YeE-yN-d6Q">
-                                        <rect key="frame" x="20" y="142.66666603088379" width="335" height="44.666667938232422"/>
+                                        <rect key="frame" x="20" y="141.66666603088379" width="335" height="44.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="YeE-yN-d6Q" id="zfQ-Td-vWJ">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="44.666667938232422"/>
@@ -1702,7 +1699,7 @@ All rights reserved.</string>
                             <tableViewSection footerTitle="Start NFC and read OATH accounts when the application has been opened by reading the OTP tag on a YubiKey." id="JSq-rh-zB3">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="xLu-6A-op7">
-                                        <rect key="frame" x="20" y="267.33333206176758" width="335" height="44.666667938232422"/>
+                                        <rect key="frame" x="20" y="266.33333206176758" width="335" height="44.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xLu-6A-op7" id="J6T-hD-CK4">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="44.666667938232422"/>
@@ -1711,7 +1708,7 @@ All rights reserved.</string>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="2fV-hk-Nye">
                                                     <rect key="frame" x="20" y="-3" width="295" height="50.666666666666664"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start NFC on OTP tag read" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Byl-RD-bpD">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Activate NFC on OTP tag read" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Byl-RD-bpD">
                                                             <rect key="frame" x="0.0" y="15.333333333333334" width="231" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
@@ -1746,7 +1743,7 @@ All rights reserved.</string>
                             <tableViewSection footerTitle="Copy OTP to clipboard when a YubiKey has been scanned using the NFC tag functionality." id="oy6-QK-Bgw">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Jey-gn-Ds9">
-                                        <rect key="frame" x="20" y="391.99999809265137" width="335" height="44.666667938232422"/>
+                                        <rect key="frame" x="20" y="390.99999809265137" width="335" height="44.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Jey-gn-Ds9" id="dq0-Qu-GIJ">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="44.666667938232422"/>

--- a/Authenticator/UI/YubiKeyConfiguration/NFCSettingsController.swift
+++ b/Authenticator/UI/YubiKeyConfiguration/NFCSettingsController.swift
@@ -16,12 +16,14 @@
 
 import UIKit
 
-class ApplicationSettingsController: UITableViewController {
+class NFCSettingsController: UITableViewController {
     
     private var viewModel = ApplicationSettingsViewModel()
 
     @IBOutlet weak var bypassTouchSwitch: UISwitch!
     @IBOutlet weak var nfcOnAppLaunchSwitch: UISwitch!
+    @IBOutlet weak var nfcOnOTPLaunchSwitch: UISwitch!
+    @IBOutlet weak var copyOTPSwitch: UISwitch!
 
     func dismiss() {
         dismiss(animated: true, completion: nil)
@@ -35,10 +37,20 @@ class ApplicationSettingsController: UITableViewController {
         viewModel.isNFCOnAppLaunchEnabled = sender.isOn
     }
     
+    @IBAction func changeNFCOnOTPLaunchSetting(_ sender: UISwitch) {
+        viewModel.isNFCOnOTPLaunchEnabled = sender.isOn
+    }
+    
+    @IBAction func changeCopyOTPSetting(_ sender: UISwitch) {
+        viewModel.isCopyOTPEnabled = sender.isOn
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         bypassTouchSwitch.isOn = viewModel.isBypassTouchEnabled
         nfcOnAppLaunchSwitch.isOn = viewModel.isNFCOnAppLaunchEnabled
+        nfcOnOTPLaunchSwitch.isOn = viewModel.isNFCOnOTPLaunchEnabled
+        copyOTPSwitch.isOn = viewModel.isCopyOTPEnabled
      }
     
     deinit {

--- a/Authenticator/VersionHistory.plist
+++ b/Authenticator/VersionHistory.plist
@@ -4,6 +4,18 @@
 <array>
     <dict>
         <key>version</key>
+        <string>1.7.4</string>
+        <key>date</key>
+        <date>2023-06-01T09:41:00Z</date>
+        <key>shouldPromptUser</key>
+        <false/>
+        <key>changes</key>
+        <string>
+            NFC magic!
+        </string>
+    </dict>
+    <dict>
+        <key>version</key>
         <string>1.7.3</string>
         <key>date</key>
         <date>2023-05-10T09:41:00Z</date>

--- a/Authenticator/VersionHistory.plist
+++ b/Authenticator/VersionHistory.plist
@@ -6,12 +6,12 @@
         <key>version</key>
         <string>1.7.4</string>
         <key>date</key>
-        <date>2023-06-01T09:41:00Z</date>
+        <date>2023-05-24T09:41:00Z</date>
         <key>shouldPromptUser</key>
         <false/>
         <key>changes</key>
         <string>
-            NFC magic!
+            Tapping a YubiKey with OTP over NFC enabled will now open the app if the user taps the notification. The OTP will be displayed by the app and OATH accounts will be scanned. Immediate scanning of OATH accounts can be turned off in settings.
         </string>
     </dict>
     <dict>


### PR DESCRIPTION
This will open the app when the user taps on the notification that's shown when you tap a YubiKey with OTP over NFC enabled. The app will initiate a NFC OATH scan for accounts when the app is opened. This can be disabled in settings. There's also a setting to automatically copy the OTP to the clipboard.