### PR TITLE
Fixing CI issues

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,6 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Test on emulator
         run: xcodebuild clean test -disablePackageRepositoryCache -sdk iphonesimulator -project Authenticator.xcodeproj -scheme Authenticator -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" | xcpretty --test --color && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
There are multiple issues relating to why the github actions build for the tests are failing:
* Node12 is deprecated and github has moved from it to node16 for running github actions. It seems that this means that actions/chekout@v2 is deprecated for actions/checkout@v3, hence this change should fix all the tests.
* It seems as if YubiKit is failing to load according to the logs, which states the likes of `fatal error: module 'YubiKit' is not defined in any loaded module map file; maybe you need to load it.` and `umbrella header for module 'YubiKit' does not include header file`.

The first seems fixed by the existing commit, but I am not sure how to move on having YubiKit loaded correctly.