### PR TITLE
Fix for issue caused by wired key with disabled OATH application

### DIFF
--- a/Authenticator/UI/ErrorAlertView.swift
+++ b/Authenticator/UI/ErrorAlertView.swift
@@ -17,11 +17,12 @@
 import SwiftUI
 
 extension View {
-    func errorAlert(error: Binding<Error?>, buttonTitle: String = "OK") -> some View {
+    func errorAlert(error: Binding<Error?>, buttonTitle: String = "OK", handler: (() -> Void)? = nil) -> some View {
         let localizedAlertError = LocalizedAlertError(error: error.wrappedValue)
         return alert(isPresented: .constant(localizedAlertError != nil), error: localizedAlertError) { _ in
             Button(buttonTitle) {
                 error.wrappedValue = nil
+                handler?()
             }
         } message: { error in
             Text(error.recoverySuggestion ?? "")

--- a/Authenticator/UI/MainView.swift
+++ b/Authenticator/UI/MainView.swift
@@ -178,7 +178,8 @@ struct MainView: View {
             Button("Never for this YubiKey") { model.passwordSaveType.send(.some(.never)) }
             Button("Not now" , role: .cancel) { model.passwordSaveType.send(nil) }
         }
-        .errorAlert(error: $model.error)
+        .errorAlert(error: $model.sessionError)
+        .errorAlert(error: $model.connectionError) { model.start() }
         .onAppear {
             if ApplicationSettingsViewModel().isNFCOnAppLaunchEnabled {
                 model.updateAccountsOverNFC()


### PR DESCRIPTION
If a USB-C or Lightning YubiKey with OATH disabled was inserted the app would end up in a state where it no longer read the list of credentials of any YubiKeys inserted thereafter.