### PR TITLE
Disable YubiOTP in SmartCard extension

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -83,7 +83,7 @@
 		B40D61A22AE7F89500467AE9 /* DisableOTPModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D61A12AE7F89500467AE9 /* DisableOTPModel.swift */; };
 		B40F44452B27033A000D5E02 /* TokenRequestYubiOTPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40F44442B27033A000D5E02 /* TokenRequestYubiOTPViewController.swift */; };
 		B411242F29D423A300D58001 /* ListStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B411242E29D423A300D58001 /* ListStatusView.swift */; };
-		B432B1BF28B65B8600A7182F /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = B432B1BE28B65B8600A7182F /* YubiKit */; };
+		B42A39332B2A03D20039DB26 /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = B42A39322B2A03D20039DB26 /* YubiKit */; };
 		B452EC1F2A1E4F460045E5D9 /* YubiOtpRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B452EC1E2A1E4F460045E5D9 /* YubiOtpRowView.swift */; };
 		B452EC3D2A264A620045E5D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B452EC3C2A264A620045E5D9 /* ToastView.swift */; };
 		B452EC442A2A06940045E5D9 /* ToastPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B452EC432A2A06940045E5D9 /* ToastPresenter.swift */; };
@@ -265,7 +265,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B432B1BF28B65B8600A7182F /* YubiKit in Frameworks */,
+				B42A39332B2A03D20039DB26 /* YubiKit in Frameworks */,
 				B9F0FF11F842A39183974083 /* (null) in Frameworks */,
 				51AFD4DA271D4278008F2630 /* QuartzCore.framework in Frameworks */,
 			);
@@ -584,7 +584,7 @@
 			);
 			name = Authenticator;
 			packageProductDependencies = (
-				B432B1BE28B65B8600A7182F /* YubiKit */,
+				B42A39322B2A03D20039DB26 /* YubiKit */,
 			);
 			productName = Authenticator;
 			productReference = 818866B322DFD729006BC0A8 /* Authenticator.app */;
@@ -645,7 +645,7 @@
 			);
 			mainGroup = 818866AA22DFD729006BC0A8;
 			packageReferences = (
-				B432B1BD28B65B8600A7182F /* XCRemoteSwiftPackageReference "yubikit-ios" */,
+				B42A39312B2A03D20039DB26 /* XCLocalSwiftPackageReference "../yubikit-ios" */,
 			);
 			productRefGroup = 818866B422DFD729006BC0A8 /* Products */;
 			projectDirPath = "";
@@ -1006,7 +1006,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Authenticator/Authenticator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 126;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				HEADER_SEARCH_PATHS = "../Submodules/YubiKit/**";
 				INFOPLIST_FILE = Authenticator/Info.plist;
@@ -1016,7 +1016,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "";
-				MARKETING_VERSION = 1.7.8;
+				MARKETING_VERSION = 1.7.9;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yubico.Authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1034,7 +1034,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Authenticator/Authenticator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 126;
 				DEVELOPMENT_TEAM = LQA3CS5MM7;
 				HEADER_SEARCH_PATHS = "../Submodules/YubiKit/**";
 				INFOPLIST_FILE = Authenticator/Info.plist;
@@ -1044,7 +1044,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "";
-				MARKETING_VERSION = 1.7.8;
+				MARKETING_VERSION = 1.7.9;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yubico.Authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1140,21 +1140,16 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		B432B1BD28B65B8600A7182F /* XCRemoteSwiftPackageReference "yubikit-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Yubico/yubikit-ios";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		B42A39312B2A03D20039DB26 /* XCLocalSwiftPackageReference "../yubikit-ios" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../yubikit-ios";
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		B432B1BE28B65B8600A7182F /* YubiKit */ = {
+		B42A39322B2A03D20039DB26 /* YubiKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B432B1BD28B65B8600A7182F /* XCRemoteSwiftPackageReference "yubikit-ios" */;
 			productName = YubiKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		B40327762847AE0A00DF4DB0 /* Licensing.md in Resources */ = {isa = PBXBuildFile; fileRef = B40327752847AE0A00DF4DB0 /* Licensing.md */; };
 		B40D61A02AE7F37900467AE9 /* DisableOTPView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D619F2AE7F37900467AE9 /* DisableOTPView.swift */; };
 		B40D61A22AE7F89500467AE9 /* DisableOTPModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D61A12AE7F89500467AE9 /* DisableOTPModel.swift */; };
+		B40F44452B27033A000D5E02 /* TokenRequestYubiOTPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40F44442B27033A000D5E02 /* TokenRequestYubiOTPViewController.swift */; };
 		B411242F29D423A300D58001 /* ListStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B411242E29D423A300D58001 /* ListStatusView.swift */; };
 		B432B1BF28B65B8600A7182F /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = B432B1BE28B65B8600A7182F /* YubiKit */; };
 		B452EC1F2A1E4F460045E5D9 /* YubiOtpRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B452EC1E2A1E4F460045E5D9 /* YubiOtpRowView.swift */; };
@@ -224,6 +225,7 @@
 		B40327752847AE0A00DF4DB0 /* Licensing.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Licensing.md; sourceTree = "<group>"; };
 		B40D619F2AE7F37900467AE9 /* DisableOTPView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableOTPView.swift; sourceTree = "<group>"; };
 		B40D61A12AE7F89500467AE9 /* DisableOTPModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableOTPModel.swift; sourceTree = "<group>"; };
+		B40F44442B27033A000D5E02 /* TokenRequestYubiOTPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRequestYubiOTPViewController.swift; sourceTree = "<group>"; };
 		B411242E29D423A300D58001 /* ListStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListStatusView.swift; sourceTree = "<group>"; };
 		B452EC1E2A1E4F460045E5D9 /* YubiOtpRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YubiOtpRowView.swift; sourceTree = "<group>"; };
 		B452EC3C2A264A620045E5D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 			children = (
 				5156D05C265D2602007A94F8 /* TokenRequestViewController.swift */,
 				B4FE90D32A443D8400B59170 /* TokenRequestWrapper.swift */,
+				B40F44442B27033A000D5E02 /* TokenRequestYubiOTPViewController.swift */,
 			);
 			path = TokenSession;
 			sourceTree = "<group>";
@@ -720,6 +723,7 @@
 				A525965B23A45501006AA3C0 /* UIImageAdditions.swift in Sources */,
 				51A162862678A1F100C3FA1E /* OATHConfigurationController.swift in Sources */,
 				515542622649C88900B19C59 /* PasswordConfigurationViewModel.swift in Sources */,
+				B40F44452B27033A000D5E02 /* TokenRequestYubiOTPViewController.swift in Sources */,
 				B4C93E60299D156C00C2A8B8 /* ErrorAlertView.swift in Sources */,
 				A591411D23830EB800CCCF67 /* UIApplicationExtension.swift in Sources */,
 				81FA3C34231AF2D8009C22AB /* AdvancedSettingsViewController.swift in Sources */,

--- a/Authenticator/UI/Base.lproj/Main.storyboard
+++ b/Authenticator/UI/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -1197,7 +1197,7 @@ All rights reserved.</string>
                             <tableViewSection headerTitle="" footerTitle="" id="a4m-Y3-hnM">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="PYZ-Wa-hkr" userLabel="Header">
-                                        <rect key="frame" x="20" y="345.00000190734858" width="335" height="192.00000000000006"/>
+                                        <rect key="frame" x="20" y="345.00000190734863" width="335" height="192"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PYZ-Wa-hkr" id="kmi-YO-gZK">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="192"/>
@@ -1535,6 +1535,103 @@ All rights reserved.</string>
             </objects>
             <point key="canvasLocation" x="3004" y="395"/>
         </scene>
+        <!--Token Request YubiOTP View Controller-->
+        <scene sceneID="v7S-Dh-IKI">
+            <objects>
+                <viewController storyboardIdentifier="TokenRequestYubiOTPViewController" id="7On-ME-dQ2" customClass="TokenRequestYubiOTPViewController" customModule="Authenticator" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="oX2-Js-kbZ">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="8kr-pH-b2j">
+                                <rect key="frame" x="15" y="50" width="345" height="69"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Yubico OTP has been disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Icc-EW-Cgh">
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="33.666666666666664"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remove and re-insert your YubiKey" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AGQ-n1-pV3">
+                                        <rect key="frame" x="0.0" y="48.666666666666671" width="345" height="20.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" alpha="0.0" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="1c1-GL-iId">
+                                <rect key="frame" x="15" y="50" width="345" height="400.33333333333331"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Yubico OTP enabled" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="26R-OJ-dML">
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="33.666666666666664"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JN3-vC-kaK">
+                                        <rect key="frame" x="0.0" y="48.666666666666664" width="345" height="101.66666666666669"/>
+                                        <string key="text">This YubiKey has Yubico OTP enabled which makes it appear as an external keyboard to the iPhone. Unfortunately this causes problem with the normal on-screen keyboard.</string>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yo4-ef-tkZ">
+                                        <rect key="frame" x="0.0" y="165.33333333333334" width="345" height="34.333333333333343"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="filled" title="Disable Yubico OTP (recommended)"/>
+                                        <connections>
+                                            <action selector="disableOTP" destination="7On-ME-dQ2" eventType="touchUpInside" id="v8c-2U-l2e"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cou-Cr-QYP">
+                                        <rect key="frame" x="0.0" y="214.66666666666669" width="345" height="69.666666666666686"/>
+                                        <string key="text">Disabling Yubico OTP will prevent the YubiKey from appearing as a keyboard. If you don’t use Yubico OTP this is the recommended solution. This can be re-enabled from the settings page.</string>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kAX-Sn-d4r">
+                                        <rect key="frame" x="0.0" y="299.33333333333331" width="345" height="34.333333333333314"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="filled" title="Continue with limited usability"/>
+                                        <connections>
+                                            <action selector="ignoreThisKey" destination="7On-ME-dQ2" eventType="touchUpInside" id="RY7-qj-Zax"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JQM-z3-Kvc">
+                                        <rect key="frame" x="0.0" y="348.66666666666669" width="345" height="51.666666666666686"/>
+                                        <string key="text">While the YubiKey is inserted the on-screen keyboard will not appear. To show the keyboard you will have to remove the YubiKey and then re-insert it.</string>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="JN3-vC-kaK" firstAttribute="top" secondItem="26R-OJ-dML" secondAttribute="bottom" constant="15" id="47W-Vv-fHi"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="q6Y-KM-ZyP"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="8kr-pH-b2j" firstAttribute="leading" secondItem="q6Y-KM-ZyP" secondAttribute="leading" constant="15" id="8zq-JL-IhM"/>
+                            <constraint firstItem="1c1-GL-iId" firstAttribute="trailing" secondItem="q6Y-KM-ZyP" secondAttribute="trailing" constant="-15" id="Fay-OP-7eo"/>
+                            <constraint firstItem="1c1-GL-iId" firstAttribute="top" secondItem="q6Y-KM-ZyP" secondAttribute="top" id="WJu-g5-KY6"/>
+                            <constraint firstItem="8kr-pH-b2j" firstAttribute="top" secondItem="q6Y-KM-ZyP" secondAttribute="top" id="hzk-cu-OyF"/>
+                            <constraint firstItem="q6Y-KM-ZyP" firstAttribute="trailing" secondItem="8kr-pH-b2j" secondAttribute="trailing" constant="15" id="uRe-kj-Rjy"/>
+                            <constraint firstItem="1c1-GL-iId" firstAttribute="leading" secondItem="q6Y-KM-ZyP" secondAttribute="leading" constant="15" id="yIm-jp-tud"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="completedView" destination="8kr-pH-b2j" id="rem-3m-JKL"/>
+                        <outlet property="optionsView" destination="1c1-GL-iId" id="8SR-5H-fhz"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dEg-FW-5hy" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="576.79999999999995" y="-1969.2118226600985"/>
+        </scene>
     </scenes>
     <color key="tintColor" name="YubiBlue"/>
     <resources>
@@ -1558,7 +1655,7 @@ All rights reserved.</string>
             <color red="0.19599999487400055" green="0.37299999594688416" blue="0.45500001311302185" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Authenticator/UI/Base.lproj/Main.storyboard
+++ b/Authenticator/UI/Base.lproj/Main.storyboard
@@ -1543,24 +1543,24 @@ All rights reserved.</string>
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="8kr-pH-b2j">
-                                <rect key="frame" x="15" y="50" width="345" height="69"/>
+                            <stackView opaque="NO" alpha="0.0" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="8kr-pH-b2j">
+                                <rect key="frame" x="25" y="85" width="325" height="69"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Yubico OTP has been disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Icc-EW-Cgh">
-                                        <rect key="frame" x="0.0" y="0.0" width="345" height="33.666666666666664"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Yubico OTP has been disabled" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Icc-EW-Cgh">
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="33.666666666666664"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remove and re-insert your YubiKey" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AGQ-n1-pV3">
-                                        <rect key="frame" x="0.0" y="48.666666666666671" width="345" height="20.333333333333329"/>
+                                        <rect key="frame" x="0.0" y="48.666666666666657" width="325" height="20.333333333333329"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" alpha="0.0" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="1c1-GL-iId">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="1c1-GL-iId">
                                 <rect key="frame" x="15" y="50" width="345" height="400.33333333333331"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Yubico OTP enabled" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="26R-OJ-dML">
@@ -1615,11 +1615,11 @@ All rights reserved.</string>
                         <viewLayoutGuide key="safeArea" id="q6Y-KM-ZyP"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="8kr-pH-b2j" firstAttribute="leading" secondItem="q6Y-KM-ZyP" secondAttribute="leading" constant="15" id="8zq-JL-IhM"/>
+                            <constraint firstItem="8kr-pH-b2j" firstAttribute="leading" secondItem="q6Y-KM-ZyP" secondAttribute="leading" constant="25" id="8zq-JL-IhM"/>
                             <constraint firstItem="1c1-GL-iId" firstAttribute="trailing" secondItem="q6Y-KM-ZyP" secondAttribute="trailing" constant="-15" id="Fay-OP-7eo"/>
                             <constraint firstItem="1c1-GL-iId" firstAttribute="top" secondItem="q6Y-KM-ZyP" secondAttribute="top" id="WJu-g5-KY6"/>
-                            <constraint firstItem="8kr-pH-b2j" firstAttribute="top" secondItem="q6Y-KM-ZyP" secondAttribute="top" id="hzk-cu-OyF"/>
-                            <constraint firstItem="q6Y-KM-ZyP" firstAttribute="trailing" secondItem="8kr-pH-b2j" secondAttribute="trailing" constant="15" id="uRe-kj-Rjy"/>
+                            <constraint firstItem="8kr-pH-b2j" firstAttribute="top" secondItem="q6Y-KM-ZyP" secondAttribute="top" constant="35" id="hzk-cu-OyF"/>
+                            <constraint firstItem="q6Y-KM-ZyP" firstAttribute="trailing" secondItem="8kr-pH-b2j" secondAttribute="trailing" constant="25" id="uRe-kj-Rjy"/>
                             <constraint firstItem="1c1-GL-iId" firstAttribute="leading" secondItem="q6Y-KM-ZyP" secondAttribute="leading" constant="15" id="yIm-jp-tud"/>
                         </constraints>
                     </view>

--- a/Authenticator/UI/TokenSession/TokenRequestViewController.swift
+++ b/Authenticator/UI/TokenSession/TokenRequestViewController.swift
@@ -39,6 +39,10 @@ class TokenRequestViewController: UIViewController, UITextFieldDelegate {
     
     override func viewDidLoad() {
         NotificationCenter.default.addObserver(self, selector: #selector(didEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         defaultAccessoryTest = accessoryLabel.text
         overlayView.alpha = 0
         arrowHintView.alpha = 0
@@ -48,11 +52,11 @@ class TokenRequestViewController: UIViewController, UITextFieldDelegate {
         if !YubiKitDeviceCapabilities.supportsISO7816NFCTags {
             orView.alpha = 0
             nfcView.alpha = 0
+        } else {
+            orView.alpha = 1
+            nfcView.alpha = 1
         }
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        
         // We need to tighten the vertical spacing to make room for the keyboard on smaller screens
         if UIScreen.main.bounds.width <= 320 {
             topHeadingConstraint.constant = 40
@@ -70,7 +74,7 @@ class TokenRequestViewController: UIViewController, UITextFieldDelegate {
         passwordTextField.delegate = self
         
         viewModel?.isYubiOTPEnabledOverUSBC { yubiOTPEnabled in
-            if yubiOTPEnabled {
+            if let yubiOTPEnabled, yubiOTPEnabled == true {
                 DispatchQueue.main.async {
                     let storyboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
                     let vc: TokenRequestYubiOTPViewController = storyboard.instantiateViewController(withIdentifier: "TokenRequestYubiOTPViewController") as! TokenRequestYubiOTPViewController

--- a/Authenticator/UI/TokenSession/TokenRequestYubiOTPViewController.swift
+++ b/Authenticator/UI/TokenSession/TokenRequestYubiOTPViewController.swift
@@ -18,9 +18,12 @@ class TokenRequestYubiOTPViewController: UIViewController {
     
     @IBAction func disableOTP() {
         viewModel?.disableOTP { error in
-            guard error == nil else { return }
-            UIView.animate(withDuration: 0.5) {
-                DispatchQueue.main.async {
+            guard error == nil else {
+                self.presentError(error)
+                return
+            }
+            DispatchQueue.main.async {
+                UIView.animate(withDuration: 0.5) {
                     self.optionsView.alpha = 0
                     self.completedView.alpha = 1
                     self.viewModel?.waitForKeyRemoval {
@@ -33,10 +36,19 @@ class TokenRequestYubiOTPViewController: UIViewController {
     
     @IBAction func ignoreThisKey() {
         viewModel?.ignoreThisKey { error in
-            guard error == nil else { return }
+            guard error == nil else {
+                self.presentError(error)
+                return
+            }
             DispatchQueue.main.async {
                 self.dismiss(animated: true)
             }
         }
+    }
+    
+    private func presentError(_ error: Error?) {
+        guard let error else { return }
+        let alert = UIAlertController(title: "Error reading YubiKey", message: "\(error.localizedDescription)\n\nRemove and reinsert your YubiKey.") { self.dismiss(animated: true) }
+        self.present(alert, animated: true, completion: nil)
     }
 }

--- a/Authenticator/UI/TokenSession/TokenRequestYubiOTPViewController.swift
+++ b/Authenticator/UI/TokenSession/TokenRequestYubiOTPViewController.swift
@@ -16,6 +16,13 @@ class TokenRequestYubiOTPViewController: UIViewController {
     @IBOutlet weak var optionsView: UIStackView!
     @IBOutlet weak var completedView: UIStackView!
     
+    
+    override func viewDidLoad() {
+        self.viewModel?.waitForKeyRemoval { [weak self] in
+            self?.dismiss(animated: true)
+        }
+    }
+    
     @IBAction func disableOTP() {
         viewModel?.disableOTP { error in
             guard error == nil else {
@@ -26,9 +33,6 @@ class TokenRequestYubiOTPViewController: UIViewController {
                 UIView.animate(withDuration: 0.5) {
                     self.optionsView.alpha = 0
                     self.completedView.alpha = 1
-                    self.viewModel?.waitForKeyRemoval {
-                        self.dismiss(animated: true)
-                    }
                 }
             }
         }

--- a/Authenticator/UI/TokenSession/TokenRequestYubiOTPViewController.swift
+++ b/Authenticator/UI/TokenSession/TokenRequestYubiOTPViewController.swift
@@ -1,0 +1,42 @@
+//
+//  TokenRequestYubiOTP.swift
+//  Authenticator
+//
+//  Created by Jens Utbult on 2023-12-11.
+//  Copyright © 2023 Yubico. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 14.0, *)
+class TokenRequestYubiOTPViewController: UIViewController {
+    
+    var viewModel: TokenRequestViewModel?
+
+    @IBOutlet weak var optionsView: UIStackView!
+    @IBOutlet weak var completedView: UIStackView!
+    
+    @IBAction func disableOTP() {
+        viewModel?.disableOTP { error in
+            guard error == nil else { return }
+            UIView.animate(withDuration: 0.5) {
+                DispatchQueue.main.async {
+                    self.optionsView.alpha = 0
+                    self.completedView.alpha = 1
+                    self.viewModel?.waitForKeyRemoval {
+                        self.dismiss(animated: true)
+                    }
+                }
+            }
+        }
+    }
+    
+    @IBAction func ignoreThisKey() {
+        viewModel?.ignoreThisKey { error in
+            guard error == nil else { return }
+            DispatchQueue.main.async {
+                self.dismiss(animated: true)
+            }
+        }
+    }
+}

--- a/Authenticator/VersionHistory.plist
+++ b/Authenticator/VersionHistory.plist
@@ -11,7 +11,7 @@
         <false/>
         <key>changes</key>
         <string>
-            Improved handling on iPhone 15 with YubiKeys that have Yubico OTP enabled when using the SmartCard extension.
+            This version solves a bug that caused a "Credential not found" error to be displayed instead of a list of accounts. Improved handling on iPhone 15 with YubiKeys that have Yubico OTP enabled when using the SmartCard extension.
         </string>
     </dict>
     <dict>

--- a/Authenticator/VersionHistory.plist
+++ b/Authenticator/VersionHistory.plist
@@ -2,7 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <array>
-    
+    <dict>
+        <key>version</key>
+        <string>1.7.9</string>
+        <key>date</key>
+        <date>2023-12-20T09:41:00Z</date>
+        <key>shouldPromptUser</key>
+        <false/>
+        <key>changes</key>
+        <string>
+            Improved handling on iPhone 15 with YubiKeys that have Yubico OTP enabled when using the SmartCard extension.
+        </string>
+    </dict>
     <dict>
         <key>version</key>
         <string>1.7.8</string>


### PR DESCRIPTION
On iPhone 15 a USB-C YubiKey with YubiOTP enabled is identified as a keyboard. Unlike iPadOS there are not buttons to bring up the normal keyboard. This will bring up a dialog helping the user disabling the YubiOTP application on the YubiKey.