### PR TITLE
Fixes issue where secrets with spaces in didn't work properly

### DIFF
--- a/Authenticator/UI/Authentication/AddCredential/AddCredentialController.swift
+++ b/Authenticator/UI/Authentication/AddCredential/AddCredentialController.swift
@@ -126,7 +126,7 @@ class AddCredentialController: UITableViewController {
         do {
             switch mode {
             case .manual:
-                let secret = NSData.ykf_data(withBase32String: self.secretManualText.text ?? "") ?? Data()
+                let secret = NSData.ykf_data(withBase32String: self.secretManualText.text?.replacingOccurrences(of: " ", with: "") ?? "") ?? Data()
                 let credentialType = YKFOATHCredentialType.typeFromString(advancedSettings[0][typeIndex])
                 let algorithm = YKFOATHCredentialAlgorithm.algorithmFromString(advancedSettings[1][algorithmIndex])
                 


### PR DESCRIPTION
Meta adds spaces in their secrets for increased readability. This is also the code that gets copied if you press the "copy code" button.