### PR TITLE
Various fixes for 1.8

### DIFF
--- a/Authenticator/Localizable.xcstrings
+++ b/Authenticator/Localizable.xcstrings
@@ -1063,7 +1063,24 @@
         }
       }
     },
+    "FIDO management over USB-C is not supported by iOS. Use NFC or the desktop Yubico Authenticator instead." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La gestion FIDO via USB-C n'est pas prise en charge par iOS. Utilisez plutôt la NFC ou Yubico Authenticator."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB-C経由のFIDO管理はiOSではサポートされていません。代わりにNFCまたはデスクトップのYubico Authenticatorをご利用ください。"
+          }
+        }
+      }
+    },
     "FIDO over USB-C is not supported by iOS. Use NFC or the desktop Yubico Authenticator instead." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3000,6 +3017,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "スマートカード拡張機能では、Yubico Authenticatorの通知を有効にする必要があります。iOS設定で有効にしてください。"
+          }
+        }
+      }
+    },
+    "The YubiKey has no more storage for OATH accounts." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La clé YubiKey n'a plus d'espace de stockage pour les comptes OATH."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YubiKeyにはもうOATHアカウント用のストレージはない。"
           }
         }
       }

--- a/Authenticator/Model/FIDOPINViewModel.swift
+++ b/Authenticator/Model/FIDOPINViewModel.swift
@@ -23,7 +23,7 @@ enum FidoViewModelError: Error, LocalizedError {
         case .pinsDoNotMatch:
             return String(localized: "PINs don't match")
         case .usbNotSupported:
-            return String(localized: "FIDO over USB-C is not supported by iOS. Use NFC or the desktop Yubico Authenticator instead.")
+            return String(localized: "FIDO management over USB-C is not supported by iOS. Use NFC or the desktop Yubico Authenticator instead.")
         case .timeout:
             return String(localized: "Operation timed out.")
         case .locked:

--- a/Authenticator/Model/FIDOResetViewModel.swift
+++ b/Authenticator/Model/FIDOResetViewModel.swift
@@ -122,7 +122,7 @@ extension FIDOResetViewModel {
             guard let session else { self.state = .error(error!); return }
             
             let version = session.version
-            guard version != YKFVersion(string: "5.7.2") else {
+            guard version < YKFVersion(string: "5.7.0") || version > YKFVersion(string: "5.7.2") else {
                 DispatchQueue.main.async {
                     self.state = .error(FidoViewModelError.notSupportedOverLightning)
                 }

--- a/Authenticator/UI/MainView.swift
+++ b/Authenticator/UI/MainView.swift
@@ -129,7 +129,6 @@ struct MainView: View {
                         Button(action: { showConfiguration.toggle() }) {
                             Label("Configuration", systemImage: "switch.2")
                         }
-                        .disabled(!YubiKitDeviceCapabilities.supportsISO7816NFCTags && !model.isKeyPluggedIn)
                         Button(action: { showAbout.toggle() }) {
                             Label("About", systemImage: "questionmark.circle")
                         }

--- a/Authenticator/UI/MainView.swift
+++ b/Authenticator/UI/MainView.swift
@@ -129,6 +129,7 @@ struct MainView: View {
                         Button(action: { showConfiguration.toggle() }) {
                             Label("Configuration", systemImage: "switch.2")
                         }
+                        .disabled(!YubiKitDeviceCapabilities.supportsISO7816NFCTags && !model.isKeyPluggedIn)
                         Button(action: { showAbout.toggle() }) {
                             Label("About", systemImage: "questionmark.circle")
                         }


### PR DESCRIPTION
- Exlude all 5Ci keys from 5.7.0 to 5.7.2 from FIDO reset.
- FIDO error message for USB-C changed to be more clear it's only FIDO management and not usage that's effected.
- Translations for "No more space for OATH accounts" for fr and jp pulled from crowdin.