### PR TITLE
Stop app from trying to start NFC on iPad

### DIFF
--- a/Authenticator/Localizable.xcstrings
+++ b/Authenticator/Localizable.xcstrings
@@ -106,7 +106,7 @@
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@ (build %2$@)"
           }
         },
@@ -1858,6 +1858,29 @@
         }
       }
     },
+    "Invalid device info received from YubiKey" : {
+      "comment" : "Internal error message not to be displayed to the user.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informations invalides sur le dispositif reçues de YubiKey"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YubiKey から無効なデバイス情報を受信しました。"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid device info received from YubiKey"
+          }
+        }
+      }
+    },
     "Invalid signature" : {
       "comment" : "PIV extension NFC invalid signature\nPIV extension invalid signature",
       "localizations" : {
@@ -2125,6 +2148,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ďalej"
+          }
+        }
+      }
+    },
+    "NFC not supported on this device" : {
+      "comment" : "Internal error message not to be displayed to the user.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La technologie NFC n'est pas prise en charge par cet appareil"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスではNFCはサポートされていません"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "NFC not supported on this device"
           }
         }
       }

--- a/Authenticator/Model/OATHSession.swift
+++ b/Authenticator/Model/OATHSession.swift
@@ -22,6 +22,7 @@ enum OATHSessionError: Error, LocalizedError, Equatable {
     case otpEnabledError
     case connectionCancelled
     case invalidDeviceInfo
+    case nfcNotSupported
     
     public var errorDescription: String? {
         switch self {
@@ -33,6 +34,8 @@ enum OATHSessionError: Error, LocalizedError, Equatable {
             return String(localized: "Connection cancelled by user", comment: "Internal error message not to be displayed to the user.")
         case .invalidDeviceInfo:
             return String(localized: "Invalid device info received from YubiKey", comment: "Internal error message not to be displayed to the user.")
+        case .nfcNotSupported:
+            return String(localized: "NFC not supported on this device", comment: "Internal error message not to be displayed to the user.")
         }
     }
 }
@@ -213,6 +216,7 @@ class OATHSessionHandler: NSObject, YKFManagerDelegate {
     
     var nfcContinuation: CheckedContinuation<OATHSession, Error>?
     func nfcSession() async throws -> OATHSession {
+        guard YubiKitDeviceCapabilities.supportsISO7816NFCTags else { throw OATHSessionError.nfcNotSupported }
         return try await withTaskCancellationHandler {
             return try await withCheckedThrowingContinuation { continuation in
                 self.nfcContinuation = continuation

--- a/Authenticator/UI/MainView.swift
+++ b/Authenticator/UI/MainView.swift
@@ -248,6 +248,12 @@ struct MainView: View {
                 showAccountDetails = nil
             }
         }
+        .onChange(of: model.isKeyPluggedIn) { isKeyPluggedIn in
+            // If the user removes the YubiKey while adding a new account we dismiss the add account modal.
+            if showAddAccount && !isKeyPluggedIn {
+                showAddAccount = false
+            }
+        }
         .environmentObject(model)
     }
     

--- a/Authenticator/UI/mul.lproj/Main.xcstrings
+++ b/Authenticator/UI/mul.lproj/Main.xcstrings
@@ -578,7 +578,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktivácia funkcie NFC pri OTP prečítaná"
+            "value" : "Aktivovať NFC pri načítaní tagu OTP"
           }
         }
       }


### PR DESCRIPTION
Fixes an issue where the app would try to start NFC on iPad if a user removed the YubiKey while trying to add a new account.