### PR TITLE
Fix for TOTP codes not updating when the views disappeared

### DIFF
--- a/Authenticator/Model/MainViewModel.swift
+++ b/Authenticator/Model/MainViewModel.swift
@@ -94,9 +94,6 @@ class MainViewModel: ObservableObject {
                     await MainActor.run { [weak self] in
                         self?.favoritesCancellables.forEach { $0.cancel() }
                         self?.favoritesCancellables.removeAll()
-                        self?.accounts.forEach { account in
-                            account.invalidate()
-                        }
                         self?.accounts.removeAll()
                         self?.pinnedAccounts.removeAll()
                         self?.otherAccounts.removeAll()
@@ -123,9 +120,6 @@ class MainViewModel: ObservableObject {
     @MainActor func stop() {
         sessionTask?.cancel()
         sessionTask = nil
-        accounts.forEach { account in
-            account.invalidate()
-        }
         accounts.removeAll()
         pinnedAccounts.removeAll()
         otherAccounts.removeAll()

--- a/Authenticator/UI/AccountRowView.swift
+++ b/Authenticator/UI/AccountRowView.swift
@@ -175,7 +175,7 @@ struct AccountRowView: View {
                 }
             }
             .onDisappear {
-                account.invalidate()
+                //account.invalidate()
             }
             .readFrame($cellFrame)
     }
@@ -189,7 +189,7 @@ struct PieProgressView: View {
     var body: some View {
         PieShape(progress: self.progress)
             .foregroundColor(color)
-            .animation(.linear(duration: self.progress == 1.0 ? 0.0 : 1.0), value: self.progress)
+            .animation(.linear(duration: self.progress >= 1.0 ? 0.0 : 1.0), value: self.progress)
     }
 }
 

--- a/Authenticator/UI/AccountRowView.swift
+++ b/Authenticator/UI/AccountRowView.swift
@@ -32,6 +32,9 @@ struct AccountRowView: View {
 
     @State private var pillScaling: CGFloat = 1.0
     @State private var pillOpacity: Double
+
+    @State private var animate: Bool = true
+
     private let pillColor = Color(.secondaryLabel)
     
     init(account: Account, showAccountDetails: Binding<AccountDetailsData?>) {
@@ -89,7 +92,9 @@ struct AccountRowView: View {
                                 .accessibilityHidden(true)
                         }
                     case .countingdown(let remaining):
-                        PieProgressView(progress: remaining, color: pillColor)
+                        PieProgressView(progress: remaining,
+                                        color: pillColor,
+                                        animate: animate)
                             .frame(width: 22, height: 22)
                             .padding(1)
                             .readFrame($statusIconFrame)
@@ -174,8 +179,11 @@ struct AccountRowView: View {
                     }
                 }
             }
+            .onAppear() {
+                animate = true
+            }
             .onDisappear {
-                //account.invalidate()
+                animate = false
             }
             .readFrame($cellFrame)
     }
@@ -183,13 +191,22 @@ struct AccountRowView: View {
 
 struct PieProgressView: View {
     
-    var progress: Double
-    var color: Color? = nil
-    
+    let progress: Double
+    let color: Color
+    let animate: Bool
+
+    init(progress: Double, color: Color, animate: Bool = true) {
+        self.progress = progress
+        self.color = color
+        self.animate = animate
+    }
+
     var body: some View {
-        PieShape(progress: self.progress)
+        var duration = progress >= 1.0 ? 0.0 : 1.0
+        duration = animate ? duration : 0.0
+        return PieShape(progress: self.progress)
             .foregroundColor(color)
-            .animation(.linear(duration: self.progress >= 1.0 ? 0.0 : 1.0), value: self.progress)
+            .animation(.linear(duration: duration), value: self.progress)
     }
 }
 


### PR DESCRIPTION
### Motivation
There was a bug where when the SwiftUI View disappeared from the view hierarchy we would destroy the timer and invalidate the account. On long lists of TOTP codes this was a problem since each view will disappear from the view hierarchy when the user scrolls up and down.

### Changes
- Use a single static timer for all updates since we only need to trigger once per seconds independently of each individual TOPT
- Improve the animation for the pie indicator since when the view re-entered the view hierarchy it would interpolate more then 1s and it would look strange