### PR TITLE
Better naming for FIPS keys

### DIFF
--- a/Authenticator/UI/YubiKeyConfiguration/ConfigurationView.swift
+++ b/Authenticator/UI/YubiKeyConfiguration/ConfigurationView.swift
@@ -227,23 +227,32 @@ struct ListIconView: View {
 
 extension YKFManagementDeviceInfo {
     var deviceName: String {
+
+        let deviceName: String
         switch formFactor {
         case .usbaKeychain:
             let name: String
             if version.major == 5 { name = "5" } else
             if version.major < 4 { name = "NEO" }
             else { name = "" }
-            return "YubiKey \(name) NFC"
+            deviceName = "YubiKey \(name) NFC"
+            break
         case .usbcKeychain:
-            return "YubiKey 5C NFC"
+            deviceName = "YubiKey 5C NFC"
         case .usbcLightning:
-            return "YubiKey 5Ci"
+            deviceName = "YubiKey 5Ci"
         case .usbcBio, .usbaBio:
-            return "YubiKey Bio"
+            deviceName = "YubiKey Bio"
         case .usbcNano:
-            return "YubiKey Nano"
+            deviceName = "YubiKey Nano"
         default:
             return "Unknown key"
+        }
+
+        if (isFIPSCapable & 0b00001000 != 0) || isFips {
+            return deviceName + " FIPS"
+        } else {
+            return deviceName
         }
     }
     

--- a/Authenticator/UI/YubiKeyConfiguration/ConfigurationView.swift
+++ b/Authenticator/UI/YubiKeyConfiguration/ConfigurationView.swift
@@ -249,7 +249,7 @@ extension YKFManagementDeviceInfo {
             return "Unknown key"
         }
 
-        if (isFIPSCapable & 0b00001000 != 0) || isFips {
+        if (isFIPSCapable != 0) || isFips {
             return deviceName + " FIPS"
         } else {
             return deviceName


### PR DESCRIPTION
### Motivation
There have been reports that FIPS keys are not properly named within the app.


### Changes
- Append ` FIPS` to the name when the key reports it.