### PR TITLE
Fix error loop when OATH applet is disabled

### DIFF
--- a/Authenticator/Localizable.xcstrings
+++ b/Authenticator/Localizable.xcstrings
@@ -5953,6 +5953,9 @@
         }
       }
     },
+    "The OATH application is disabled on this YubiKey." : {
+      "comment" : "OATH disabled error message"
+    },
     "The passwords do not match" : {
       "comment" : "Configuration set password not matching error alert message",
       "extractionState" : "stale",

--- a/Authenticator/Model/MainViewModel.swift
+++ b/Authenticator/Model/MainViewModel.swift
@@ -115,6 +115,9 @@ class MainViewModel: ObservableObject {
                 if let sessionError = error as? OATHSessionError {
                     if sessionError == .otpEnabledError {
                         self?.presentDisableOTP = true
+                    } else if sessionError == .oathDisabledError {
+                        // Don't set connectionError to avoid restart loop - use sessionError instead
+                        self?.sessionError = error
                     } else if sessionError != .connectionCancelled {
                         self?.connectionError = error
                     }

--- a/Authenticator/Model/OATHSession.swift
+++ b/Authenticator/Model/OATHSession.swift
@@ -17,9 +17,10 @@
 import Foundation
 
 enum OATHSessionError: Error, LocalizedError, Equatable {
-    
+
     case credentialAlreadyPresent(YKFOATHCredentialTemplate)
     case otpEnabledError
+    case oathDisabledError
     case connectionCancelled
     case invalidDeviceInfo
     case nfcNotSupported
@@ -31,6 +32,8 @@ enum OATHSessionError: Error, LocalizedError, Equatable {
             return "\(String(localized: "There's already an account named", comment: "OATH substring in 'There's already an account named [issuer, name] on this YubiKey.")) \(credential.issuer.isEmpty == false ? "\(credential.issuer), \(credential.accountName)" : credential.accountName) \(String(localized: "on this YubiKey", comment: "OATH substring in 'There's already an account named [issuer, name] on this YubiKey."))."
         case .otpEnabledError:
             return String(localized: "Yubico OTP enabled", comment: "OATH otp enabled error message")
+        case .oathDisabledError:
+            return String(localized: "The OATH application is disabled on this YubiKey.", comment: "OATH disabled error message")
         case .connectionCancelled:
             return String(localized: "Connection cancelled by user", comment: "Internal error message not to be displayed to the user.")
         case .invalidDeviceInfo:
@@ -184,6 +187,8 @@ class OATHSessionHandler: NSObject, YKFManagerDelegate {
                                     if let session {
                                         self.currentSession = session
                                         self.wiredContinuation?.resume(returning: OATHSession(session: session, type: .wired))
+                                    } else if let nsError = error as? NSError, nsError.domain == "com.yubico", nsError.code == 0x5 {
+                                        self.wiredContinuation?.resume(throwing: OATHSessionError.oathDisabledError)
                                     } else {
                                         self.wiredContinuation?.resume(throwing: error!)
                                     }
@@ -198,6 +203,8 @@ class OATHSessionHandler: NSObject, YKFManagerDelegate {
                             if let session {
                                 self.currentSession = session
                                 self.wiredContinuation?.resume(returning: OATHSession(session: session, type: .wired))
+                            } else if let nsError = error as? NSError, nsError.domain == "com.yubico", nsError.code == 0x5 {
+                                self.wiredContinuation?.resume(throwing: OATHSessionError.oathDisabledError)
                             } else {
                                 self.wiredContinuation?.resume(throwing: error!)
                             }

--- a/Authenticator/Model/OATHSession.swift
+++ b/Authenticator/Model/OATHSession.swift
@@ -33,7 +33,7 @@ enum OATHSessionError: Error, LocalizedError, Equatable {
         case .otpEnabledError:
             return String(localized: "Yubico OTP enabled", comment: "OATH otp enabled error message")
         case .oathDisabledError:
-            return String(localized: "The OATH application is disabled on this YubiKey.", comment: "OATH disabled error message")
+            return String(localized: "The OATH application is disabled or not supported on this YubiKey.", comment: "OATH disabled error message")
         case .connectionCancelled:
             return String(localized: "Connection cancelled by user", comment: "Internal error message not to be displayed to the user.")
         case .invalidDeviceInfo:


### PR DESCRIPTION

addressing this issue:

> If OATH is disabled on a YubiKey, Yubico Authenticator on iOS will continuously loop the error “The requested functionality is missing or disabled in this YubiKey.” If you dismiss the error, it comes right back.