### PR TITLE
Support PIV over SCP

### DIFF
--- a/Authenticator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Authenticator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/Yubico/yubikit-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "805cab56042303254070f46414dbef24e0fa2abc"
+        "revision" : "0bf31a793b004ae0e196c0c09ed1f46896352426"
       }
     }
   ],

--- a/Authenticator/Model/Extensions/YKFConnectionProtocol+Extensions.swift
+++ b/Authenticator/Model/Extensions/YKFConnectionProtocol+Extensions.swift
@@ -16,52 +16,85 @@
 
 
 extension YKFConnectionProtocol {
-    func oathSession(completion: @escaping (YKFOATHSession?, Bool, Error?) -> Void) {
-        if self as? YKFNFCConnection != nil {
-            self.managementSession { managementSession, error in
-                guard let managementSession else {
-                    // FIX for CRI-667: most likely the key doesn't support the management application
-                    self.oathSession { session, error in
-                        completion(session, false, error)
-                    }
+
+    /// Checks if the key requires SCP for a given capability over NFC and provides SCP11 key params if needed.
+    /// - Parameters:
+    ///   - fipsCapabilityMask: The bitmask to check against isFIPSCapable (e.g., 0b00001000 for OATH, 0b00010000 for PIV)
+    ///   - completion: Returns SCP11KeyParams if SCP is required and setup succeeded, nil otherwise, or an error
+    private func getSCP11KeyParamsIfNeeded(fipsCapabilityMask: UInt, completion: @escaping (YKFSCP11KeyParams?, Error?) -> Void) {
+        guard self as? YKFNFCConnection != nil else {
+            completion(nil, nil)
+            return
+        }
+
+        self.managementSession { managementSession, error in
+            guard let managementSession else {
+                // CRI-667: the key most likely doesn't support the management application
+                completion(nil, nil)
+                return
+            }
+            managementSession.getDeviceInfo { deviceInfo, error in
+                guard let deviceInfo else {
+                    completion(nil, error)
                     return
                 }
-                managementSession.getDeviceInfo { deviceInfo, error in
-                    guard let deviceInfo else {
-                        completion(nil, false, error)
-                        return
-                    }
-                    if deviceInfo.isFIPSCapable & 0b00001000 == 0b00001000 {
-                        self.securityDomainSession { session, error in
-                            guard let session else {
-                                completion(nil, false, error)
+                if deviceInfo.isFIPSCapable & fipsCapabilityMask == fipsCapabilityMask {
+                    self.securityDomainSession { session, error in
+                        guard let session else {
+                            completion(nil, error)
+                            return
+                        }
+                        let scpKeyRef = YKFSCPKeyRef(kid: 0x13, kvn: 0x01)
+                        session.getCertificateBundle(with: scpKeyRef) { certificates, error in
+                            guard let last = certificates?.last else {
+                                completion(nil, error)
                                 return
                             }
-                            let scpKeyRef = YKFSCPKeyRef(kid: 0x13, kvn: 0x01)
-                            session.getCertificateBundle(with: scpKeyRef) { certificates, error in
-                                guard let last = certificates?.last else {
-                                    completion(nil, false, error)
-                                    return
-                                }
-                                let certificate = last as! SecCertificate
-                                let publicKey = SecCertificateCopyKey(certificate)!
-                                let scp11KeyParams = YKFSCP11KeyParams(keyRef: scpKeyRef, pkSdEcka: publicKey)
-                                self.oathSession(scp11KeyParams) { session, error in
-                                    completion(session, error == nil ? true : false, error)
-                                    return
-                                }
-                            }
-                        }
-                    } else {
-                        self.oathSession { session, error in
-                            completion(session, false, error)
+                            let certificate = last as! SecCertificate
+                            let publicKey = SecCertificateCopyKey(certificate)!
+                            let scp11KeyParams = YKFSCP11KeyParams(keyRef: scpKeyRef, pkSdEcka: publicKey)
+                            completion(scp11KeyParams, nil)
                         }
                     }
+                } else {
+                    completion(nil, nil)
                 }
             }
-        } else {
-            self.oathSession { session, error in
-                completion(session, false, error)
+        }
+    }
+
+    func oathSession(completion: @escaping (YKFOATHSession?, Bool, Error?) -> Void) {
+        getSCP11KeyParamsIfNeeded(fipsCapabilityMask: 0b00001000) { scpKeyParams, error in
+            if let error {
+                completion(nil, false, error)
+                return
+            }
+            if let scpKeyParams {
+                self.oathSession(scpKeyParams) { session, error in
+                    completion(session, error == nil, error)
+                }
+            } else {
+                self.oathSession { session, error in
+                    completion(session, false, error)
+                }
+            }
+        }
+    }
+
+    func pivSession(completion: @escaping (YKFPIVSession?, Bool, Error?) -> Void) {
+        getSCP11KeyParamsIfNeeded(fipsCapabilityMask: 0b00010000) { scpKeyParams, error in
+            if let error {
+                completion(nil, false, error)
+                return
+            }
+            if let scpKeyParams {
+                self.pivSession(scpKeyParams) { session, error in
+                    completion(session, error == nil, error)
+                }
+            } else {
+                self.pivSession { session, error in
+                    completion(session, false, error)
+                }
             }
         }
     }

--- a/Authenticator/Model/SmartCardViewModel.swift
+++ b/Authenticator/Model/SmartCardViewModel.swift
@@ -72,7 +72,7 @@ class SmartCardViewModel: NSObject {
         tokensCallback?(.success(tokens))
         
         guard let connection = connection else { return }
-        connection.pivSession { session, error in
+        connection.pivSession { session, _, error in
             guard let session = session else { self.certificatesCallback?(.failure(error!)); return }
             guard let callback = self.certificatesCallback else { return }
             var certificates = [Certificate]()

--- a/Authenticator/Model/TokenRequestViewModel.swift
+++ b/Authenticator/Model/TokenRequestViewModel.swift
@@ -99,7 +99,7 @@ class TokenRequestViewModel: NSObject {
 
     func handleTokenRequest(_ userInfo: [AnyHashable: Any], password: String, completion: @escaping (TokenError?) -> Void) {
         connection.startConnection { connection in
-            connection.pivSession { session, error in
+            connection.pivSession { session, _, error in
                 guard let session = session else { Logger.ctk.error("No session: \(error!)"); return }
                 guard let operationType = userInfo.operationType() else { Logger.ctk.error("No OperationType defined"); return }
                 guard let type = userInfo.keyType(),


### PR DESCRIPTION
addressing this issue:

> Yubico Authenticator on iOS cannot read the certificates on a FIPS YubiKey over NFC. FIPS requires secure messaging over NFC.

Now that https://github.com/Yubico/yubikit-ios/pull/181 was merged.