### PR TITLE
Improve DisableOTP reliability and error handling

### DIFF
--- a/Authenticator/AuthenticatorApp.swift
+++ b/Authenticator/AuthenticatorApp.swift
@@ -23,13 +23,15 @@ struct AuthenticatorApp: App {
     @Environment(\.scenePhase) var scenePhase
     @StateObject var toastPresenter = ToastPresenter()
     @StateObject var notificationsViewModel = NotificationsViewModel()
+    @StateObject var mainViewModel = MainViewModel()
     
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                MainView()
-                    .toast(isPresenting: $toastPresenter.isPresenting, message: toastPresenter.message)
-            }
+            MainView()
+                .toast(isPresenting: $toastPresenter.isPresenting, message: toastPresenter.message)
+                .fullScreenCover(isPresented: $notificationsViewModel.presentDisableOTP) {
+                    DisableOTPView()
+                }
             .fullScreenCover(isPresented: $notificationsViewModel.showPIVTokenView) {
                 TokenRequestView(userInfo: notificationsViewModel.userInfo)
             }
@@ -39,6 +41,7 @@ struct AuthenticatorApp: App {
             .navigationViewStyle(.stack)
             .environmentObject(toastPresenter)
             .environmentObject(notificationsViewModel)
+            .environmentObject(mainViewModel)
             .onAppear {
                 YubiKitExternalLocalization.nfcScanAlertMessage = String(localized: "Scan your YubiKey", comment: "iOS NFC alert scan")
                 YubiKitExternalLocalization.nfcScanSuccessAlertMessage = String(localized: "Success", comment: "iOS NFC alert default success message")

--- a/Authenticator/Localizable.xcstrings
+++ b/Authenticator/Localizable.xcstrings
@@ -4781,6 +4781,7 @@
       }
     },
     "Remove and re-insert your YubiKey" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7531,6 +7532,7 @@
       }
     },
     "Yubico OTP has been disabled" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Authenticator/Model/DisableOTPModel.swift
+++ b/Authenticator/Model/DisableOTPModel.swift
@@ -18,115 +18,49 @@ import Foundation
 import OSLog
 
 class DisableOTPModel: ObservableObject {
-    private let sessionHandler = ManagementSessionHandler()
-    
+
     @Published var otpDisabled: Bool = false
-    @Published var keyRemoved: Bool = false
     @Published var keyIgnored: Bool = false
-    
+    @Published var isConfigurationLocked: Bool = false
+
     init() {
-        sessionHandler.closingCallback = { [weak self] error in
-            DispatchQueue.main.async {
-                self?.keyRemoved = true
-            }
-        }
         Logger.allocation.debug("DisableOTPModel: init")
+        checkConfigurationLocked()
     }
-    
+
     deinit {
         Logger.allocation.debug("DisableOTPModel: deinit")
     }
-    
+
+    private func checkConfigurationLocked() {
+        Task { @MainActor in
+            guard let connection = OATHSessionHandler.shared.smartCardConnection else { return }
+            guard let session = try? await connection.managementSession() else { return }
+            guard let deviceInfo = try? await session.deviceInfo() else { return }
+            guard let configuration = deviceInfo.configuration else { return }
+            self.isConfigurationLocked = configuration.isConfigurationLocked
+        }
+    }
+
     func disableOTP() {
         Task { @MainActor in
-            guard let session = try? await self.sessionHandler.session() else { return }
+            guard let connection = OATHSessionHandler.shared.smartCardConnection else { return }
+            guard let session = try? await connection.managementSession() else { return }
             guard let deviceInfo = try? await session.deviceInfo() else { return }
             guard let configuration = deviceInfo.configuration else { return }
             configuration.setEnabled(false, application: .OTP, overTransport: .USB)
-            try await session.write(configuration, reboot: false)
+            try? await session.write(configuration, reboot: false)
             self.otpDisabled = true
         }
     }
-    
+
     func ignoreThisKey() {
         Task { @MainActor in
-            guard let session = try? await self.sessionHandler.session() else { return }
+            guard let connection = OATHSessionHandler.shared.smartCardConnection else { return }
+            guard let session = try? await connection.managementSession() else { return }
             guard let deviceInfo = try? await session.deviceInfo() else { return }
             SettingsConfig.registerUSBCDeviceToIgnore(deviceId: deviceInfo.serialNumber)
             self.keyIgnored = true
         }
     }
-}
-
-fileprivate class ManagementSessionHandler: NSObject, YKFManagerDelegate {
-    
-    override init() {
-        super.init()
-        YubiKitManager.shared.delegate = self
-        Logger.allocation.debug("ManagementSessionHandler: init")
-    }
-    
-    deinit {
-        YubiKitManager.shared.delegate = nil
-        Logger.allocation.debug("ManagementSessionHandler: deinit")
-    }
-    
-    private var smartCardConnection: YKFSmartCardConnection?
-    private var currentSession: YKFManagementSession?
-    
-    private var connectionCallback: ((_ connection: YKFConnectionProtocol) -> Void)?
-    fileprivate var closingCallback: ((_ error: Error?) -> Void)?
-    
-    func didConnectSmartCard(_ connection: YKFSmartCardConnection) {
-        smartCardConnection = connection
-        connectionCallback?(connection)
-        connectionCallback = nil
-    }
-    
-    func didDisconnectSmartCard(_ connection: YKFSmartCardConnection, error: Error?) {
-        smartCardConnection = nil
-        closingCallback?(error)
-        closingCallback = nil
-        currentSession = nil
-    }
-    
-    var completion: ((YKFNFCConnection) -> Void)?
-    
-    func session() async throws -> YKFManagementSession {
-        return try await withCheckedThrowingContinuation { continuation in
-            guard !Task.isCancelled else {
-                continuation.resume(throwing: CancellationError())
-                return
-            }
-            if let smartCardConnection {
-                smartCardConnection.managementSession { session, error in
-                    if let session {
-                        continuation.resume(returning: session)
-                    } else {
-                        continuation.resume(throwing: error!)
-                    }
-                }
-                return
-            }
-            
-            self.completion = { connection in
-                connection.managementSession { session, error in
-                    if let session {
-                        continuation.resume(returning: session)
-                    } else {
-                        continuation.resume(throwing: error!)
-                    }
-                    self.completion = nil
-                }
-            }
-        }
-    }
-}
-
-extension ManagementSessionHandler {
-    // Not used but implemented to conform to YKFManagerDelegate protocol.
-    func didConnectNFC(_ connection: YKFNFCConnection) { }
-    func didDisconnectNFC(_ connection: YKFNFCConnection, error: Error?) { }
-    func didConnectAccessory(_ connection: YKFAccessoryConnection) { }
-    func didDisconnectAccessory(_ connection: YKFAccessoryConnection, error: Error?) { }
 }

--- a/Authenticator/Model/DisableOTPModel.swift
+++ b/Authenticator/Model/DisableOTPModel.swift
@@ -19,9 +19,10 @@ import OSLog
 
 class DisableOTPModel: ObservableObject {
 
-    @Published var otpDisabled: Bool = false
     @Published var keyIgnored: Bool = false
     @Published var isConfigurationLocked: Bool = false
+    @Published var isDisablingOTP: Bool = false
+    @Published var error: Error?
 
     init() {
         Logger.allocation.debug("DisableOTPModel: init")
@@ -43,14 +44,20 @@ class DisableOTPModel: ObservableObject {
     }
 
     func disableOTP() {
+        guard !isDisablingOTP else { return }
+        isDisablingOTP = true
         Task { @MainActor in
             guard let connection = OATHSessionHandler.shared.smartCardConnection else { return }
             guard let session = try? await connection.managementSession() else { return }
             guard let deviceInfo = try? await session.deviceInfo() else { return }
             guard let configuration = deviceInfo.configuration else { return }
             configuration.setEnabled(false, application: .OTP, overTransport: .USB)
-            try? await session.write(configuration, reboot: false)
-            self.otpDisabled = true
+            do {
+                try await session.write(configuration, reboot: true)
+            } catch {
+                self.error = error
+                isDisablingOTP = false
+            }
         }
     }
 

--- a/Authenticator/Model/MainViewModel.swift
+++ b/Authenticator/Model/MainViewModel.swift
@@ -114,6 +114,7 @@ class MainViewModel: ObservableObject {
             } catch {
                 if let sessionError = error as? OATHSessionError {
                     if sessionError == .otpEnabledError {
+                        self?.isKeyPluggedIn = true
                         self?.presentDisableOTP = true
                     } else if sessionError == .oathDisabledError {
                         // Don't set connectionError to avoid restart loop - use sessionError instead

--- a/Authenticator/Model/NotificationsViewModel.swift
+++ b/Authenticator/Model/NotificationsViewModel.swift
@@ -17,8 +17,9 @@
 import SwiftUI
 
 class NotificationsViewModel: NSObject, ObservableObject, UNUserNotificationCenterDelegate {
-    
+
     @Published var showPIVTokenView: Bool = false
+    @Published var presentDisableOTP: Bool = false
     var userInfo: [AnyHashable: Any]?
     
     override init() {

--- a/Authenticator/Model/OATHSession.swift
+++ b/Authenticator/Model/OATHSession.swift
@@ -48,9 +48,9 @@ enum OATHSessionError: Error, LocalizedError, Equatable {
 
 
 class OATHSessionHandler: NSObject, YKFManagerDelegate {
-    
+
     typealias ClosingCallback = ((_ error: Error?) -> Void)
-    
+
     var nfcConnection: YKFNFCConnection?
     var smartCardConnection: YKFSmartCardConnection?
     var accessoryConnection: YKFAccessoryConnection?

--- a/Authenticator/Model/OATHSession.swift
+++ b/Authenticator/Model/OATHSession.swift
@@ -156,49 +156,7 @@ class OATHSessionHandler: NSObject, YKFManagerDelegate {
             return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<OATHSession, Error>) in
                 self.wiredContinuation = continuation
                 self.wiredConnectionCallback = { connection in
-                    if connection.isKind(of: YKFSmartCardConnection.self) && deviceType == .phone {
-                        connection.managementSession { session, error in
-                            guard let session else {
-                                self.wiredContinuation?.resume(throwing: error!)
-                                self.wiredContinuation = nil
-                                self.wiredConnectionCallback = nil
-                                return
-                            }
-                            session.getDeviceInfo { deviceInfo, error in
-                                guard let deviceInfo else {
-                                    self.wiredContinuation?.resume(throwing: error!)
-                                    self.wiredContinuation = nil
-                                    self.wiredConnectionCallback = nil
-                                    return
-                                }
-                                guard let configuration = deviceInfo.configuration else {
-                                    self.wiredContinuation?.resume(throwing: OATHSessionError.invalidDeviceInfo)
-                                    self.wiredContinuation = nil
-                                    self.wiredConnectionCallback = nil
-                                    return
-                                }
-                                guard !configuration.isEnabled(.OTP, overTransport: .USB) || SettingsConfig.isOTPOverUSBIgnored(deviceId: deviceInfo.serialNumber) else {
-                                    self.wiredContinuation?.resume(throwing: OATHSessionError.otpEnabledError)
-                                    self.wiredContinuation = nil
-                                    self.wiredConnectionCallback = nil
-                                    return
-                                }
-                                connection.oathSession { session, error in
-                                    if let session {
-                                        self.currentSession = session
-                                        self.wiredContinuation?.resume(returning: OATHSession(session: session, type: .wired))
-                                    } else if let nsError = error as? NSError, nsError.domain == "com.yubico", nsError.code == 0x5 {
-                                        self.wiredContinuation?.resume(throwing: OATHSessionError.oathDisabledError)
-                                    } else {
-                                        self.wiredContinuation?.resume(throwing: error!)
-                                    }
-                                    self.wiredContinuation = nil
-                                    self.wiredConnectionCallback = nil
-                                    return
-                                }
-                            }
-                        }
-                    } else {
+                    let connectOATHDirectly = {
                         connection.oathSession { session, error in
                             if let session {
                                 self.currentSession = session
@@ -211,6 +169,37 @@ class OATHSessionHandler: NSObject, YKFManagerDelegate {
                             self.wiredContinuation = nil
                             self.wiredConnectionCallback = nil
                         }
+                    }
+                    if connection.isKind(of: YKFSmartCardConnection.self) && deviceType == .phone {
+                        connection.managementSession { managementSession, error in
+                            guard let managementSession else {
+                                connectOATHDirectly()
+                                return
+                            }
+                            managementSession.getDeviceInfo { deviceInfo, error in
+                                guard let deviceInfo, let configuration = deviceInfo.configuration else {
+                                    // NEO (version 3.x) needs de-select workaround after Management Applet
+                                    // See: https://github.com/Yubico/yubikit-manager/blob/main/yubikit/support.py#L89
+                                    if managementSession.version.major == 3 {
+                                        connection.executeRawCommand(Data([0xa4, 0x04, 0x00, 0x08])) { _, _ in
+                                            connectOATHDirectly()
+                                        }
+                                    } else {
+                                        connectOATHDirectly()
+                                    }
+                                    return
+                                }
+                                guard !configuration.isEnabled(.OTP, overTransport: .USB) || SettingsConfig.isOTPOverUSBIgnored(deviceId: deviceInfo.serialNumber) else {
+                                    self.wiredContinuation?.resume(throwing: OATHSessionError.otpEnabledError)
+                                    self.wiredContinuation = nil
+                                    self.wiredConnectionCallback = nil
+                                    return
+                                }
+                                connectOATHDirectly()
+                            }
+                        }
+                    } else {
+                        connectOATHDirectly()
                     }
                 }
                 if let connection: YKFConnectionProtocol = self.accessoryConnection ?? self.smartCardConnection {

--- a/Authenticator/UI/DisableOTPView.swift
+++ b/Authenticator/UI/DisableOTPView.swift
@@ -17,10 +17,11 @@
 import SwiftUI
 
 struct DisableOTPView: View {
-    
+
+    @EnvironmentObject var notificationsViewModel: NotificationsViewModel
     @EnvironmentObject var mainViewModel: MainViewModel
     @StateObject var model = DisableOTPModel()
-    
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 5) {
@@ -33,7 +34,9 @@ struct DisableOTPView: View {
                     } label: {
                         Text("Disable Yubico OTP (recommended)")
                             .frame(maxWidth: .infinity)
-                    }.buttonStyle(.borderedProminent)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(model.isConfigurationLocked)
                     Text("Disabling Yubico OTP will prevent the YubiKey from appearing as a keyboard. If you don’t use Yubico OTP this is the recommended solution. This can be re-enabled from the settings page.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -60,14 +63,24 @@ struct DisableOTPView: View {
             }
             .padding(30)
             .accentColor(Color(UIColor.yubiBlue))
-            .onChange(of: model.keyRemoved, perform: { value in
-                mainViewModel.start()
-                mainViewModel.presentDisableOTP = false
-            })
-            .onChange(of: model.keyIgnored, perform: { value in
-                mainViewModel.start()
-                mainViewModel.presentDisableOTP = false
-            })
+            .task {
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    if OATHSessionHandler.shared.smartCardConnection == nil {
+                        await MainActor.run {
+                            mainViewModel.presentDisableOTP = false
+                            notificationsViewModel.presentDisableOTP = false
+                        }
+                        break
+                    }
+                }
+            }
+            .onChange(of: model.keyIgnored) { value in
+                if value {
+                    mainViewModel.presentDisableOTP = false
+                    notificationsViewModel.presentDisableOTP = false
+                }
+            }
         }
     }
 }

--- a/Authenticator/UI/DisableOTPView.swift
+++ b/Authenticator/UI/DisableOTPView.swift
@@ -25,41 +25,32 @@ struct DisableOTPView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 5) {
-                if !model.otpDisabled {
-                    Text("Yubico OTP enabled").font(.title).bold()
-                    Text("This YubiKey has Yubico OTP enabled which makes it appear as an external keyboard to the iPhone. Unfortunately this causes problem with the normal on-screen keyboard.")
-                    Spacer().frame(height: 15)
-                    Button {
-                        model.disableOTP()
-                    } label: {
-                        Text("Disable Yubico OTP (recommended)")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(model.isConfigurationLocked)
-                    Text("Disabling Yubico OTP will prevent the YubiKey from appearing as a keyboard. If you don’t use Yubico OTP this is the recommended solution. This can be re-enabled from the settings page.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                    Spacer().frame(height: 25)
-                    Button {
-                        model.ignoreThisKey()
-                    } label: {
-                        Text("Continue with limited usability")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    Text("While the YubiKey is inserted the on-screen keyboard will not appear. To show the keyboard you will have to remove the YubiKey and then re-insert it.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                } else {
-                    Text("Yubico OTP has been disabled").font(.title).bold()
-                        .frame(maxWidth: .infinity, alignment: .topLeading)
-                    Spacer().frame(height: 15)
-                    Text("Remove and re-insert your YubiKey")
-                        .frame(maxWidth: .infinity, alignment: .topLeading)
-                    Spacer()
+                Text("Yubico OTP enabled").font(.title).bold()
+                Text("This YubiKey has Yubico OTP enabled which makes it appear as an external keyboard to the iPhone. Unfortunately this causes problem with the normal on-screen keyboard.")
+                Spacer().frame(height: 15)
+                Button {
+                    model.disableOTP()
+                } label: {
+                    Text("Disable Yubico OTP (recommended)")
+                        .frame(maxWidth: .infinity)
                 }
+                .buttonStyle(.borderedProminent)
+                .disabled(model.isConfigurationLocked || model.isDisablingOTP)
+                Text("Disabling Yubico OTP will prevent the YubiKey from appearing as a keyboard. If you don’t use Yubico OTP this is the recommended solution. This can be re-enabled from the settings page.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                Spacer().frame(height: 25)
+                Button {
+                    model.ignoreThisKey()
+                } label: {
+                    Text("Continue with limited usability")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                Text("While the YubiKey is inserted the on-screen keyboard will not appear. To show the keyboard you will have to remove the YubiKey and then re-insert it.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                Spacer()
             }
             .padding(30)
             .accentColor(Color(UIColor.yubiBlue))
@@ -81,6 +72,7 @@ struct DisableOTPView: View {
                     notificationsViewModel.presentDisableOTP = false
                 }
             }
+            .errorAlert(error: $model.error)
         }
     }
 }

--- a/Authenticator/UI/MainView.swift
+++ b/Authenticator/UI/MainView.swift
@@ -23,7 +23,7 @@ struct MainView: View {
     @EnvironmentObject var toastPresenter: ToastPresenter
     @EnvironmentObject var notificationsViewModel: NotificationsViewModel
     
-    @StateObject var model = MainViewModel()
+    @EnvironmentObject var model: MainViewModel
     @State var showAccountDetails: AccountDetailsData? = nil
     @State var showAddAccount: Bool = false
     @State var addAccountCancellable: AnyCancellable?
@@ -165,14 +165,6 @@ struct MainView: View {
                     model.start()
                 }
         }
-        .fullScreenCover(isPresented: $model.presentDisableOTP) {
-            DisableOTPView()
-                .onAppear {
-                    model.stop()
-                }.onDisappear {
-                    model.start()
-                }
-        }
         .alert(String(localized: "Enter password", comment: "Password alert"), isPresented: $model.presentPasswordEntry) {
             SecureField(String(localized: "Password", comment: "Password alert"), text: $password)
             Button(String(localized: "Cancel", comment: "Password alert"), role: .cancel) { password = "" }
@@ -252,6 +244,21 @@ struct MainView: View {
                 showConfiguration = false
                 showAbout = false
                 showAccountDetails = nil
+            }
+        }
+        .onChange(of: model.presentDisableOTP) { presentDisableOTP in
+            if presentDisableOTP {
+                showAddAccount = false
+                showConfiguration = false
+                showAbout = false
+                showAccountDetails = nil
+                notificationsViewModel.presentDisableOTP = true
+            }
+        }
+        .onChange(of: notificationsViewModel.presentDisableOTP) { presentDisableOTP in
+            if !presentDisableOTP {
+                model.presentDisableOTP = false
+                model.start()
             }
         }
         .onChange(of: model.isKeyPluggedIn) { isKeyPluggedIn in


### PR DESCRIPTION
###  Improve DisableOTP reliability and error handling
Fixes a crash when the YubiKey has a configuration lock code set, and improves reliability of the "Disable Yubico OTP" prompt. The button is now disabled when the configuration is locked, and errors are properly shown to the user.