### PR TITLE
Improve PIV Certificate names

### DIFF
--- a/Authenticator/UI/Helpers/SecCertificate+Extensions.swift
+++ b/Authenticator/UI/Helpers/SecCertificate+Extensions.swift
@@ -24,6 +24,10 @@ extension SecCertificate: Equatable {
         SecCertificateCopyCommonName(self, &name)
         return name as String?
     }
+
+    var subjectSummary: String? {
+        SecCertificateCopySubjectSummary(self) as String?
+    }
     
     func tokenObjectId() -> String {
         let data = SecCertificateCopyData(self) as Data

--- a/Authenticator/UI/YubiKeyConfiguration/SmartCardConfigurationController.swift
+++ b/Authenticator/UI/YubiKeyConfiguration/SmartCardConfigurationController.swift
@@ -211,7 +211,7 @@ class SmartCardConfigurationController: UITableViewController {
             } else {
                 let cell = tableView.dequeueReusableCell(withIdentifier: "CertificateCell", for: indexPath) as! CertificateCell
                 let certificate = certificates[indexPath.row - 1]
-                cell.name = "\(certificate.certificate.commonName ?? String(localized: "No name", comment: "PIV extension certificate with no name"))  (slot \(String(format: "%02X", certificate.slot.rawValue)))"
+                cell.name = "\(certificate.certificate.subjectSummary ?? String(localized: "No name", comment: "PIV extension certificate with no name")) (slot \(String(format: "%02X", certificate.slot.rawValue)))"
                 if !tokens.contains(certificate.certificate) {
                      cell.action = { [weak self] in
                         self?.storeTokenCertificate(certificate: certificate.certificate)
@@ -236,7 +236,7 @@ class SmartCardConfigurationController: UITableViewController {
             } else {
                 let cell = tableView.dequeueReusableCell(withIdentifier: "CertificateCell", for: indexPath) as! CertificateCell
                 let token = tokens[indexPath.row - 1]
-                cell.name = token.commonName
+                cell.name = token.subjectSummary
                 cell.setSymbol(symbol: "minus.circle")
                 cell.action = { [weak self] in
                     self?.removeTokenCertificate(certificate: token)


### PR DESCRIPTION
addressing this issue:
> Yubico Authenticator for iOS smart card extension "no name" if YubiKey certificate subject has no CN (fallback to E - email) on any PIV slot


### Before
<img width="590" height="1278" alt="IMG_9300" src="https://github.com/user-attachments/assets/cb5bdd42-8419-4168-94fc-250962c97ec0" />

### After
<img width="590" height="1278" alt="IMG_9301" src="https://github.com/user-attachments/assets/cd84ed62-b8ff-4761-886e-8557b884f517" />
