### PR TITLE
Stabilise CryptoTokenKit PIV Flows

### DIFF
--- a/Authenticator/Model/Extensions/Logger+Extensions.swift
+++ b/Authenticator/Model/Extensions/Logger+Extensions.swift
@@ -24,4 +24,8 @@ public extension Logger {
     static let connection = Logger(subsystem: subsystem, category: "Connection")
     static let ctk = Logger(subsystem: subsystem, category: "CTK")
     static let system = Logger(subsystem: subsystem, category: "System")
+
+    func yubilog(_ message: String) {
+        self.debug("YUBICO_DEBUG: \(message)")
+    }
 }

--- a/Authenticator/Model/TokenRequestViewModel.swift
+++ b/Authenticator/Model/TokenRequestViewModel.swift
@@ -68,7 +68,8 @@ class TokenRequestViewModel: NSObject {
     }
     
     private var connection = Connection()
-    
+    var operationCompleted = false
+
     override init() {
         super.init()
         Logger.allocation.debug("TokenRequestViewModel: init")
@@ -98,7 +99,9 @@ class TokenRequestViewModel: NSObject {
     }
 
     func handleTokenRequest(_ userInfo: [AnyHashable: Any], password: String, completion: @escaping (TokenError?) -> Void) {
+        Logger.ctk.yubilog("App: handleTokenRequest started")
         connection.startConnection { connection in
+            Logger.ctk.yubilog("App: got connection")
             connection.pivSession { session, _, error in
                 guard let session = session else { Logger.ctk.error("No session: \(error!)"); return }
                 guard let operationType = userInfo.operationType() else { Logger.ctk.error("No OperationType defined"); return }
@@ -106,14 +109,16 @@ class TokenRequestViewModel: NSObject {
                       let objectId = userInfo.objectId(),
                       let algorithm = userInfo.algorithm(),
                       let message = userInfo.data() else { Logger.ctk.error("No data to sign"); return }
-                Logger.ctk.debug("Search for slot for objectId: \(objectId)")
+                Logger.ctk.yubilog("App: got PIV session, searching for slot")
                 session.slotForObjectId(objectId) { slot, error in
                     guard let slot = slot else {
                         YubiKitManager.shared.stopNFCConnection(withErrorMessage: error!.message.title)
                         completion(error!)
                         return
                     }
+                    Logger.ctk.yubilog("App: found slot, verifying PIN")
                     session.verifyPin(password) { result, error in
+                        Logger.ctk.yubilog("App: PIN verified, result: \(result)")
                         if let error = error {
                             let tokenError = error.tokenError
                             switch tokenError {
@@ -131,7 +136,9 @@ class TokenRequestViewModel: NSObject {
                         
                         switch operationType {
                         case .signData:
+                            Logger.ctk.yubilog("App: starting signWithKey")
                             session.signWithKey(in: slot, type: type, algorithm: algorithm, message: message) { signature, error in
+                                Logger.ctk.yubilog("App: signWithKey completed")
                                 // Handle any errors
                                 if let error = error, (error as NSError).code == 0x6a80 {
                                     YubiKitManager.shared.stopNFCConnection(withErrorMessage: String(localized: "Invalid signature", comment: "PIV extension NFC invalid signature"))
@@ -156,8 +163,11 @@ class TokenRequestViewModel: NSObject {
                                 YubiKitManager.shared.stopNFCConnection(withMessage: String(localized: "Successfully signed data", comment: "PIV extension NFC successfully signed data"))
                                 
                                 if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator") {
-                                    Logger.ctk.debug("Save data to userDefaults...")
+                                    Logger.ctk.yubilog("Writing signedData to UserDefaults")
                                     userDefaults.setValue(signature, forKey: "signedData")
+                                    userDefaults.synchronize()
+                                    Logger.ctk.yubilog("UserDefaults synchronized, operationCompleted = true")
+                                    self.operationCompleted = true
                                     completion(nil)
                                 }
                             } // End signWithKey Session
@@ -181,8 +191,11 @@ class TokenRequestViewModel: NSObject {
                                 YubiKitManager.shared.stopNFCConnection(withMessage: String(localized: "Successfully decrypted cipher data", comment: "PIV extension NFC successfully decrypted cipher data"))
                                 
                                 if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator") {
-                                    Logger.ctk.debug("Save decrypted data to userDefaults...")
+                                    Logger.ctk.yubilog("Writing decryptedData to UserDefaults")
                                     userDefaults.setValue(decryptedData, forKey: "decryptedData")
+                                    userDefaults.synchronize()
+                                    Logger.ctk.yubilog("UserDefaults synchronized, operationCompleted = true")
+                                    self.operationCompleted = true
                                     completion(nil)
                                 }
                             } // End Decryption Session
@@ -194,8 +207,12 @@ class TokenRequestViewModel: NSObject {
     }
     
     func cancel() {
+        guard !operationCompleted else {
+            Logger.ctk.yubilog("Skipping cancel - operation already completed")
+            return
+        }
         if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator") {
-            Logger.ctk.debug("Save canceledByUser to userDefaults...")
+            Logger.ctk.yubilog("Saving canceledByUser to userDefaults")
             userDefaults.setValue(true, forKey: "canceledByUser")
         }
     }

--- a/TokenExtension/TokenSession.swift
+++ b/TokenExtension/TokenSession.swift
@@ -16,9 +16,19 @@
 
 import CryptoTokenKit
 import UserNotifications
+import OSLog
+
+extension Logger {
+    private static let subsystem = "com.yubico.Authenticator.TokenExtension"
+    static let ctk = Logger(subsystem: subsystem, category: "CTK")
+
+    func yubilog(_ message: String) {
+        self.debug("YUBICO_DEBUG: \(message)")
+    }
+}
 
 class TokenSession: TKTokenSession, TKTokenSessionDelegate {
-    
+
     var sessionEndTime = Date(timeIntervalSinceNow: -10) // create endTime in the passed to force recreation of endTime when signing start
     
     // These cases match the YKFPIVKeyType in the SDK
@@ -36,12 +46,14 @@ class TokenSession: TKTokenSession, TKTokenSessionDelegate {
     }
 
     func tokenSession(_ session: TKTokenSession, beginAuthFor operation: TKTokenOperation, constraint: Any) throws -> TKTokenAuthOperation {
+        Logger.ctk.yubilog("Extension: beginAuthFor operation: \(String(describing: operation)), constraint: \(String(describing: constraint))")
         // Insert code here to create an instance of TKTokenAuthOperation based on the specified operation and constraint.
         // Note that the constraint was previously established when creating token configuration with keychain items.
         return TKTokenPasswordAuthOperation()
     }
-    
+
     func tokenSession(_ session: TKTokenSession, supports operation: TKTokenOperation, keyObjectID: Any, algorithm: TKTokenKeyAlgorithm) -> Bool {
+        Logger.ctk.yubilog("Extension: supports operation: \(String(describing: operation)), keyObjectID: \(String(describing: keyObjectID))")
         switch operation {
             case .readData, .signData, .decryptData, .performKeyExchange:
                 return true
@@ -51,16 +63,19 @@ class TokenSession: TKTokenSession, TKTokenSessionDelegate {
     }
     
     func tokenSession(_ session: TKTokenSession, sign dataToSign: Data, keyObjectID: Any, algorithm: TKTokenKeyAlgorithm) throws -> Data {
+        Logger.ctk.yubilog("Extension: sign called")
         // tokenSession() gets called multiple times even if we throw an error. This kludge make sure we only pop one notification.
-        
+
         // if we're not passed sessionEndTime throw error and cancel all notifications
         if sessionEndTime.timeIntervalSinceNow > 0 {
+            Logger.ctk.yubilog("Extension: sessionEndTime in future, throwing canceledByUser")
             cancelAllNotifications()
             throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
         }
 
         // if we're past sessionEndTime set a new endtime and reset
         if sessionEndTime.timeIntervalSinceNow < 0 {
+            Logger.ctk.yubilog("Extension: sessionEndTime in past, resetting and setting new endtime")
             reset()
             sessionEndTime = Date(timeIntervalSinceNow: 100)
         }
@@ -88,31 +103,38 @@ class TokenSession: TKTokenSession, TKTokenSessionDelegate {
             throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
         }
 
+        Logger.ctk.yubilog("Extension: sending notification for keyObjectID: \(objectId)")
         sendNotificationWithData(dataToSign, keyObjectID: objectId, keyType: keyType, algorithm: secKeyAlgorithm)
-        
+
         let loopEndTime = Date(timeIntervalSinceNow: 95)
         var runLoop = true
+        var tick = 0
         while(runLoop) {
             Thread.sleep(forTimeInterval: 1)
+            tick += 1
+            Logger.ctk.yubilog("Extension: polling tick \(tick)...")
             if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator"), let signedData = userDefaults.value(forKey: "signedData") as? Data {
-                sessionEndTime = Date(timeIntervalSinceNow: -10)
+                Logger.ctk.yubilog("Extension: Got signedData from UserDefaults")
+                sessionEndTime = Date(timeIntervalSinceNow: 5) // Set in future to block duplicate requests from CryptoTokenKit
                 reset()
                 return signedData
             }
             if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator"), let _ = userDefaults.value(forKey: "canceledByUser") {
+                Logger.ctk.yubilog("Extension: Got canceledByUser!")
                 sessionEndTime = Date(timeIntervalSinceNow: 3)
                 reset()
                 throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
             }
 
             if loopEndTime < Date() {
+                Logger.ctk.yubilog("Extension: Loop timeout!")
                 runLoop = false
             }
         }
         reset()
         throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
     }
-    
+
     // Decryption
     func tokenSession(_ session: TKTokenSession, decrypt ciphertext: Data, keyObjectID: Any, algorithm: TKTokenKeyAlgorithm) throws -> Data {
         
@@ -152,30 +174,36 @@ class TokenSession: TKTokenSession, TKTokenSessionDelegate {
         }
 
         sendNotificationWithEncryptedData(ciphertext, keyObjectID: objectId, keyType: keyType, algorithm: secKeyAlgorithm)
-        
+
         let loopEndTime = Date(timeIntervalSinceNow: 95)
         var runLoop = true
+        var tick = 0
         while(runLoop) {
             Thread.sleep(forTimeInterval: 1)
+            tick += 1
+            Logger.ctk.yubilog("Extension: decrypt polling tick \(tick)...")
             if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator"), let decryptedData = userDefaults.value(forKey: "decryptedData") as? Data {
-                sessionEndTime = Date(timeIntervalSinceNow: -10)
+                Logger.ctk.yubilog("Extension: Got decryptedData from UserDefaults")
+                sessionEndTime = Date(timeIntervalSinceNow: 5) // Set in future to block duplicate requests from CryptoTokenKit
                 reset()
                 return decryptedData
             }
             if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator"), let _ = userDefaults.value(forKey: "canceledByUser") {
+                Logger.ctk.yubilog("Extension: Got canceledByUser!")
                 sessionEndTime = Date(timeIntervalSinceNow: 3)
                 reset()
                 throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
             }
 
             if loopEndTime < Date() {
+                Logger.ctk.yubilog("Extension: Loop timeout!")
                 runLoop = false
             }
         }
         reset()
         throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
     }
-    
+
     func tokenSession(_ session: TKTokenSession, performKeyExchange otherPartyPublicKeyData: Data, keyObjectID objectID: Any, algorithm: TKTokenKeyAlgorithm, parameters: TKTokenKeyExchangeParameters) throws -> Data {
         var secret: Data?
         

--- a/TokenExtension/TokenSession.swift
+++ b/TokenExtension/TokenSession.swift
@@ -29,7 +29,8 @@ extension Logger {
 
 class TokenSession: TKTokenSession, TKTokenSessionDelegate {
 
-    var sessionEndTime = Date(timeIntervalSinceNow: -10) // create endTime in the passed to force recreation of endTime when signing start
+    var signSessionEndTime = Date(timeIntervalSinceNow: -10) // create endTime in the past to force recreation of endTime when signing starts
+    var decryptSessionEndTime = Date(timeIntervalSinceNow: -10) // create endTime in the past to force recreation of endTime when decryption starts
     
     // These cases match the YKFPIVKeyType in the SDK
     enum KeyType: UInt8 {
@@ -66,18 +67,18 @@ class TokenSession: TKTokenSession, TKTokenSessionDelegate {
         Logger.ctk.yubilog("Extension: sign called")
         // tokenSession() gets called multiple times even if we throw an error. This kludge make sure we only pop one notification.
 
-        // if we're not passed sessionEndTime throw error and cancel all notifications
-        if sessionEndTime.timeIntervalSinceNow > 0 {
-            Logger.ctk.yubilog("Extension: sessionEndTime in future, throwing canceledByUser")
+        // if we're not passed signSessionEndTime throw error and cancel all notifications
+        if signSessionEndTime.timeIntervalSinceNow > 0 {
+            Logger.ctk.yubilog("Extension: signSessionEndTime in future, throwing canceledByUser")
             cancelAllNotifications()
             throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
         }
 
-        // if we're past sessionEndTime set a new endtime and reset
-        if sessionEndTime.timeIntervalSinceNow < 0 {
-            Logger.ctk.yubilog("Extension: sessionEndTime in past, resetting and setting new endtime")
+        // if we're past signSessionEndTime set a new endtime and reset
+        if signSessionEndTime.timeIntervalSinceNow < 0 {
+            Logger.ctk.yubilog("Extension: signSessionEndTime in past, resetting and setting new endtime")
             reset()
-            sessionEndTime = Date(timeIntervalSinceNow: 100)
+            signSessionEndTime = Date(timeIntervalSinceNow: 100)
         }
         
         guard let key = try? session.token.configuration.key(for: keyObjectID), let objectId = keyObjectID as? String else {
@@ -115,19 +116,19 @@ class TokenSession: TKTokenSession, TKTokenSessionDelegate {
             Logger.ctk.yubilog("Extension: polling tick \(tick)...")
             if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator"), let signedData = userDefaults.value(forKey: "signedData") as? Data {
                 Logger.ctk.yubilog("Extension: Got signedData from UserDefaults")
-                sessionEndTime = Date(timeIntervalSinceNow: 5) // Set in future to block duplicate requests from CryptoTokenKit
+                signSessionEndTime = Date(timeIntervalSinceNow: 3) // Set in future to block duplicate requests from CryptoTokenKit
                 reset()
                 return signedData
             }
             if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator"), let _ = userDefaults.value(forKey: "canceledByUser") {
                 Logger.ctk.yubilog("Extension: Got canceledByUser!")
-                sessionEndTime = Date(timeIntervalSinceNow: 3)
+                signSessionEndTime = Date(timeIntervalSinceNow: 3)
                 reset()
                 throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
             }
 
             if loopEndTime < Date() {
-                Logger.ctk.yubilog("Extension: Loop timeout!")
+                Logger.ctk.yubilog("Extension: sign Loop timeout!")
                 runLoop = false
             }
         }
@@ -138,16 +139,16 @@ class TokenSession: TKTokenSession, TKTokenSessionDelegate {
     // Decryption
     func tokenSession(_ session: TKTokenSession, decrypt ciphertext: Data, keyObjectID: Any, algorithm: TKTokenKeyAlgorithm) throws -> Data {
         
-        // if we're not passed sessionEndTime throw error and cancel all notifications
-        if sessionEndTime.timeIntervalSinceNow > 0 {
+        // if we're not passed decryptSessionEndTime throw error and cancel all notifications
+        if decryptSessionEndTime.timeIntervalSinceNow > 0 {
             cancelAllNotifications()
             throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
         }
 
-        // if we're past sessionEndTime set a new endtime and reset
-        if sessionEndTime.timeIntervalSinceNow < 0 {
+        // if we're past decryptSessionEndTime set a new endtime and reset
+        if decryptSessionEndTime.timeIntervalSinceNow < 0 {
             reset()
-            sessionEndTime = Date(timeIntervalSinceNow: 100)
+            decryptSessionEndTime = Date(timeIntervalSinceNow: 100)
         }
         
         guard let key = try? session.token.configuration.key(for: keyObjectID), let objectId = keyObjectID as? String else {
@@ -184,19 +185,19 @@ class TokenSession: TKTokenSession, TKTokenSessionDelegate {
             Logger.ctk.yubilog("Extension: decrypt polling tick \(tick)...")
             if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator"), let decryptedData = userDefaults.value(forKey: "decryptedData") as? Data {
                 Logger.ctk.yubilog("Extension: Got decryptedData from UserDefaults")
-                sessionEndTime = Date(timeIntervalSinceNow: 5) // Set in future to block duplicate requests from CryptoTokenKit
+                decryptSessionEndTime = Date(timeIntervalSinceNow: -10)
                 reset()
                 return decryptedData
             }
             if let userDefaults = UserDefaults(suiteName: "group.com.yubico.Authenticator"), let _ = userDefaults.value(forKey: "canceledByUser") {
                 Logger.ctk.yubilog("Extension: Got canceledByUser!")
-                sessionEndTime = Date(timeIntervalSinceNow: 3)
+                decryptSessionEndTime = Date(timeIntervalSinceNow: 3)
                 reset()
                 throw NSError(domain: TKErrorDomain, code: TKError.Code.canceledByUser.rawValue, userInfo: nil)
             }
 
             if loopEndTime < Date() {
-                Logger.ctk.yubilog("Extension: Loop timeout!")
+                Logger.ctk.yubilog("Extension: decrypt Loop timeout!")
                 runLoop = false
             }
         }


### PR DESCRIPTION
adding those `sessionEndTime = Date(timeIntervalSinceNow: 5)` seems to stabilise the experience a lot in my tests with https://client.badssl.com

We are getting duplicated requests from Safari so added an extra 5s to ignore the consequent requests and it's really stable now. I can't get it to fail, not even with the key in retired slots.

Also the NFC sheet triggered writing `canceledByUser` to UserDefaults.
NFC alert triggers `applicationDidEnterBackground:` which in turn triggered the `canceledByUser` to be written.

Addressing both issues and keeping the debug logs since they were essential to figure this out.


FIY @dmennis 