### PR TITLE
Avoid conflicts with oath session when opening from the CryptoTokenKit PIV Flows

### DIFF
--- a/Authenticator/UI/MainView.swift
+++ b/Authenticator/UI/MainView.swift
@@ -224,6 +224,7 @@ struct MainView: View {
             if phase == .active && didEnterBackground {
                 didEnterBackground = false
 
+                guard !notificationsViewModel.showPIVTokenView else { return }
                 model.start() // This is called when app becomes active
             } else if phase == .background {
                 didEnterBackground = true

--- a/Authenticator/UI/TokenSession/TokenRequestViewController.swift
+++ b/Authenticator/UI/TokenSession/TokenRequestViewController.swift
@@ -72,7 +72,13 @@ class TokenRequestViewController: UIViewController, UITextFieldDelegate {
         viewModel = TokenRequestViewModel()
         passwordTextField.becomeFirstResponder()
         passwordTextField.delegate = self
-        
+        if YubiKitDeviceCapabilities.supportsMFIAccessoryKey {
+            YubiKitManager.shared.startAccessoryConnection()
+        }
+        if YubiKitDeviceCapabilities.supportsSmartCardOverUSBC {
+            YubiKitManager.shared.startSmartCardConnection()
+        }
+
         viewModel?.isYubiOTPEnabledOverUSBC { yubiOTPEnabled in
             if let yubiOTPEnabled, yubiOTPEnabled == true {
                 DispatchQueue.main.async {


### PR DESCRIPTION
This PR prevents the OATH session from starting when the app is in the CryptoTokenKit PIV flow, which would cause conflicts. It does this by:
- Guarding against `model.start()` when the PIV token view is active                                                                                   
- Explicitly starting the YubiKey connections in the PIV flow instead

https://github.com/user-attachments/assets/bef1b76d-e44c-41b3-8019-f484212ff34b

