### PR TITLE
Rename the PIV async wrapper so it doesn't conflict with same named method inside SDK

### DIFF
--- a/Authenticator/Model/SmartCardViewModel.swift
+++ b/Authenticator/Model/SmartCardViewModel.swift
@@ -75,7 +75,7 @@ class SmartCardViewModel: NSObject {
 
         Task {
             do {
-                let session = try await connection.pivSession()
+                let session = try await connection.pivSessionSCPIfNeeded()
                 var certificates = [Certificate]()
 
                 for slot in YKFPIVSlot.allSlots {
@@ -107,7 +107,7 @@ extension YKFPIVSlot {
 
 @available(iOS 14.0, *)
 extension YKFConnectionProtocol {
-    func pivSession() async throws -> YKFPIVSession {
+    func pivSessionSCPIfNeeded() async throws -> YKFPIVSession {
         try await withCheckedThrowingContinuation { continuation in
             pivSession { session, _, error in
                 if let session {


### PR DESCRIPTION
It was being shadowed by a method with the same name inside the SDK which meant SCP wasn't running anymore.

Issue introduced here https://github.com/Yubico/yubioath-ios/pull/179/changes#diff-d0365fad72b5bbc449c121d2093576b9fdc29075f89a066980066f6a75579272R109 while [Support reading certificates from retired PIV slots](https://github.com/Yubico/yubioath-ios/pull/179)